### PR TITLE
Alias for Blynk library

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
@@ -56,6 +56,9 @@ class DefaultHandler
             $filename = "Robot_Control";
         else if ($filename == "ArduinoRobotMotorBoard")
             $filename = "Robot_Motor";
+        if ($filename == 'BlynkSimpleSerial') {
+            $filename = 'BlynkSimpleEthernet';
+        }
 
         $exists = json_decode($this->checkIfBuiltInExists($filename), true);
 


### PR DESCRIPTION
### ChangeLog
Made fetching of the Blynk library available for both `BlynkSimpleSerial` and `BlynkSimpleEthernet` machine names. This will make most Blynk library examples work properly on codebender. However, BlynkSimpleSerial will be available as a separate library (same case with Arduino Robot Motor/Control).

### Merge Process
Nothing special

### QA
Not applicable