### PR TITLE
Added BlynkSimpleCC3000 machine-name alias for Blynk library

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
@@ -56,7 +56,7 @@ class DefaultHandler
             $filename = "Robot_Control";
         else if ($filename == "ArduinoRobotMotorBoard")
             $filename = "Robot_Motor";
-        if ($filename == 'BlynkSimpleSerial') {
+        if ($filename == 'BlynkSimpleSerial' || $filename == 'BlynkSimpleCC3000') {
             $filename = 'BlynkSimpleEthernet';
         }
 


### PR DESCRIPTION
### ChangeLog
Fetch Blynk library if any of the following machine names are requested:
- BlynkSimpleSerial
- BlynkSimpleEthernet
- BlynkSimpleCC3000
This make more examples of the Blynk library compile successfully

### Merge Process
Nothing special

### QA 
Not applicable