### PR TITLE
Implement getVersions API

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetVersionsCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetVersionsCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Codebender\LibraryBundle\Handler\ApiCommand;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class GetVersionsCommand extends AbstractApiCommand
+{
+    private $apiHandler;
+    
+    function __construct(EntityManager $entityManager, ContainerInterface $containerInterface)
+    {
+        parent::__construct($entityManager, $containerInterface);
+        $this->apiHandler = $this->container->get('codebender_library.apiHandler');
+    }
+
+    /**
+     * This is the main execution of the getVersions API. It
+     * returns a response that includes an array of versions
+     * belonging to the given library name if the library exists.
+     *
+     * @param $content
+     * @return array
+     */
+    public function execute($content)
+    {
+        if (!$this->isValidContent($content)) {
+            return ['success' => false, 'message' => 'Incorrect request fields'];
+        }
+
+        $defaultHeader = $content['library'];
+        if (!$this->apiHandler->isExternalLibrary($defaultHeader)) {
+            return ['success' => false, 'message' => 'Invalid library name ' . $defaultHeader];
+        }
+
+        $versions = $this->getVersionStringsFromDefaultHeader($defaultHeader);
+        return ['success' => true, 'versions' => $versions];
+    }
+
+    /**
+     * This method checks if the given $content is valid.
+     *
+     * @param $content
+     * @return bool
+     */
+    private function isValidContent($content)
+    {
+        return array_key_exists("library", $content);
+    }
+
+    /**
+     * This method returns an array of versions belonging to a library
+     * with the given default header.
+     *
+     * @param $defaultHeader
+     * @return array
+     */
+    private function getVersionStringsFromDefaultHeader($defaultHeader)
+    {
+        $versionObjects = $this->apiHandler->getAllVersionsFromDefaultHeader($defaultHeader);
+        $versionsCollection = $versionObjects->map(function ($version) {
+            return $version->getVersion();
+        });
+        $versions = $versionsCollection->toArray();
+        return $versions;
+    }
+}

--- a/Symfony/src/Codebender/LibraryBundle/Resources/config/services.yml
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ parameters:
 # Publicly accessible APIs
     codebender_api.status.class: Codebender\LibraryBundle\Handler\ApiCommand\StatusCommand
     codebender_api.invalidApi.class: Codebender\LibraryBundle\Handler\ApiCommand\InvalidApiCommand
+    codebender_api.getVersions.class: Codebender\LibraryBundle\Handler\ApiCommand\GetVersionsCommand
 
 services:
 #    codebender_library.example:
@@ -40,6 +41,12 @@ services:
 
     codebender_api.invalidApi:
             class:  %codebender_api.invalidApi.class%
+            arguments:
+                entityManager: "@doctrine.orm.entity_manager"
+                containerInterface: "@service_container"
+
+    codebender_api.getVersions:
+            class:  %codebender_api.getVersions.class%
             arguments:
                 entityManager: "@doctrine.orm.entity_manager"
                 containerInterface: "@service_container"

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -125,10 +125,8 @@ class ApiControllerTest extends WebTestCase
      */
     private function areSimilarArrays($array1, $array2)
     {
-        $arrayDiff1 = array_diff($array1, $array2);
-        $arrayDiff2 = array_diff($array2, $array1);
-        $totalDifferences = array_merge($arrayDiff1, $arrayDiff2);
-
-        return empty($totalDifferences);
+        sort($array1);
+        sort($array2);
+        return $array1 === $array2;
     }
 }

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -25,6 +25,22 @@ class ApiControllerTest extends WebTestCase
     }
 
     /**
+     * This method tests the getVersions API.
+     */
+    public function testGetVersions()
+    {
+        // Test successful getVersions calls
+        $this->assertSuccessfulGetVersions('default', ['1.0.0', '1.1.0']);
+        $this->assertSuccessfulGetVersions('DynamicArrayHelper', ['1.0.0']);
+        $this->assertSuccessfulGetVersions('HtmlLib', []);
+
+        // Test invalid getVersions calls
+        $this->assertFailedGetVersions('nonExistentLib');
+        $this->assertFailedGetVersions('');
+        $this->assertFailedGetVersions(null);
+    }
+
+    /**
      * Use this method for library manager API requests with POST data
      *
      * @param Client $client
@@ -54,5 +70,65 @@ class ApiControllerTest extends WebTestCase
         $client = $this->postApiRequest($client, $authorizationKey, '{"type":"' .$type. '"}');
         $response = json_decode($client->getResponse()->getContent(), true);
         return $response;
+    }
+
+    /**
+     * This method submits a POST request to the getVersions API
+     * and returns its response.
+     *
+     * @param $defaultHeader
+     * @return $response
+     */
+    private function postGetVersionsApi($defaultHeader)
+    {
+        $client = static::createClient();
+        $authorizationKey = $client->getContainer()->getParameter('authorizationKey');
+        $client = $this->postApiRequest($client, $authorizationKey, '{"type":"getVersions","library":"' . $defaultHeader . '"}');
+        $response = json_decode($client->getResponse()->getContent(), true);
+        return $response;
+    }
+
+    /**
+     * This method checks if the response of a single getVersions
+     * API call is successful and returns the correct versions.
+     *
+     * @param $defaultHeader
+     * @param $expectedVersions
+     */
+    private function assertSuccessfulGetVersions($defaultHeader, $expectedVersions)
+    {
+        $response = $this->postGetVersionsApi($defaultHeader);
+        $this->assertEquals(true, $response['success']);
+        $this->assertArrayHasKey('versions', $response);
+        $this->assertTrue($this->areSimilarArrays($expectedVersions, $response['versions']));
+    }
+
+    /**
+     * This method checks if the response of a single getVersions
+     * API call is unsuccessful.
+     *
+     * @param $defaultHeader
+     */
+    private function assertFailedGetVersions($defaultHeader)
+    {
+        $response = $this->postGetVersionsApi($defaultHeader);
+        $this->assertEquals(false, $response['success']);
+    }
+
+    /**
+     * This method checks if two arrays, $array1 and $array2,
+     * has the same elements.
+     *
+     * @param $array1
+     * @param $array2
+     * @return bool
+     */
+    private function areSimilarArrays($array1, $array2)
+    {
+        $arrayDiff1 = array_diff($array1, $array2);
+        $arrayDiff2 = array_diff($array2, $array1);
+        $totalDifferences = array_merge($arrayDiff1, $arrayDiff2);
+
+        return empty($totalDifferences);
     }
 }


### PR DESCRIPTION
This PR builds upon PR #39 (API base).

This API is used to list all the versions of a given library (header) name.

## Usage
POST `{"type":"getVersions","library":"<header_name>"}` to the API dispatcher

## Example
POST `{"type":"getVersions","library":"default"}` returns `{"success": true, "versions": ["1.0.0", "1.1.0"]}`