### PR TITLE
Implement getKeywords API

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Codebender\LibraryBundle\Handler\ApiCommand;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class GetKeywordsCommand extends AbstractApiCommand
+{
+    private $apiHandler;
+
+    function __construct(EntityManager $entityManager, ContainerInterface $containerInterface)
+    {
+        parent::__construct($entityManager, $containerInterface);
+        $this->apiHandler = $this->container->get('codebender_library.apiHandler');
+    }
+
+    /**
+     * This is the main execution of the getKeywords API.
+     * This method returns a response containing all the keywords of a library version.
+     *
+     * @param $content
+     * @return array
+     */
+    public function execute($content)
+    {
+        if (!$this->isValidContent($content)) {
+            return ['success' => false, 'message' => 'Incorrect request fields'];
+        }
+
+        $this->setDefaults($content);
+
+        $defaultHeader = $content['library'];
+        $version = $content['version'];
+
+        if (!$this->apiHandler->libraryVersionExists($defaultHeader, $version)) {
+            return ['success' => false, 'message' => 'Version ' .$version. ' of library named ' .$defaultHeader. ' not found.'];
+        }
+
+        $libraryType = $this->apiHandler->getLibraryType($defaultHeader);
+        if ($libraryType === 'external') {
+            $keywords = $this->getExternalLibraryKeywords($defaultHeader, $version);
+        } elseif ($libraryType === 'builtin') {
+            $keywords = $this->getBuiltInLibraryKeywords($defaultHeader);
+        } else {
+            return ['success' => false];
+        }
+
+        return ['success' => true, 'keywords' => $keywords];
+    }
+
+    /**
+     * This method checks if the given $content is valid.
+     *
+     * @param $content
+     * @return bool
+     */
+    private function isValidContent($content)
+    {
+        return array_key_exists("library", $content);
+    }
+
+    /**
+     * This method sets the default values for unset variables in $content.
+     *
+     * @param $content
+     */
+    private function setDefaults(&$content)
+    {
+        if (!array_key_exists("version", $content)) {
+            $content['version'] = '';
+        }
+    }
+
+    /**
+     * This method returns an array of keywords from a given library version
+     * specified by its $defaultHeader and $version.
+     *
+     * @param $defaultHeader
+     * @param $version
+     * @return array
+     */
+    private function getExternalLibraryKeywords($defaultHeader, $version)
+    {
+        $path = $this->apiHandler->getExternalLibraryPath($defaultHeader, $version);
+        $keywords = $this->getKeywordsFromFile($path);
+        return $keywords;
+    }
+
+    /**
+     * This method returns an array of keywords from a given built-in library
+     * specified by its $defaultHeader.
+     *
+     * @param $defaultHeader
+     * @return array
+     */
+    private function getBuiltInLibraryKeywords($defaultHeader)
+    {
+        $path = $this->apiHandler->getBuiltInLibraryPath($defaultHeader);
+        $keywords = $this->getKeywordsFromFile($path);
+        return $keywords;
+    }
+
+    /**
+     * This method returns an array of keywords found in $path.
+     *
+     * @param $path
+     * @return array
+     */
+    private function getKeywordsFromFile($path)
+    {
+        $keywords = array();
+
+        $finder = new Finder();
+        $finder->in($path);
+        $finder->name('/keywords\.txt/i');
+
+        foreach ($finder as $file) {
+            $content = (!mb_check_encoding($file->getContents(), 'UTF-8')) ? mb_convert_encoding($file->getContents(), "UTF-8") : $file->getContents();
+
+            $lines = preg_split('/\r\n|\r|\n/', $content);
+
+            foreach ($lines as $rawline) {
+
+                $line = trim($rawline);
+                $parts = preg_split('/\s+/', $line);
+
+                $totalParts = count($parts);
+
+                if (($totalParts == 2) || ($totalParts == 3)) {
+
+                    if ((substr($parts[1], 0, 7) == "KEYWORD")) {
+                        $keywords[$parts[1]][] = $parts[0];
+                    }
+
+                    if ((substr($parts[1], 0, 7) == "LITERAL")) {
+                        $keywords["KEYWORD3"][] = $parts[0];
+                    }
+
+                }
+
+            }
+
+            break;
+        }
+        return $keywords;
+    }
+}

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
@@ -35,7 +35,7 @@ class GetKeywordsCommand extends AbstractApiCommand
         $version = $content['version'];
 
         if (!$this->apiHandler->libraryVersionExists($defaultHeader, $version)) {
-            return ['success' => false, 'message' => 'Version ' .$version. ' of library named ' .$defaultHeader. ' not found.'];
+            return ['success' => false, 'message' => "Couldn't find version $version of library $defaultHeader."];
         }
 
         $libraryType = $this->apiHandler->getLibraryType($defaultHeader);

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
@@ -114,7 +114,7 @@ class GetKeywordsCommand extends AbstractApiCommand
 
         $finder = new Finder();
         $finder->in($path);
-        $finder->name('/keywords\.txt/i');
+        $finder->name('/^keywords\.txt$/i');
 
         foreach ($finder as $file) {
             $content = (!mb_check_encoding($file->getContents(), 'UTF-8')) ? mb_convert_encoding($file->getContents(), "UTF-8") : $file->getContents();

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
@@ -58,7 +58,7 @@ class GetKeywordsCommand extends AbstractApiCommand
      */
     private function isValidContent($content)
     {
-        return array_key_exists("library", $content);
+        return array_key_exists('library', $content);
     }
 
     /**

--- a/Symfony/src/Codebender/LibraryBundle/Resources/config/services.yml
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ parameters:
 # Publicly accessible APIs
     codebender_api.status.class: Codebender\LibraryBundle\Handler\ApiCommand\StatusCommand
     codebender_api.invalidApi.class: Codebender\LibraryBundle\Handler\ApiCommand\InvalidApiCommand
+    codebender_api.getKeywords.class: Codebender\LibraryBundle\Handler\ApiCommand\GetKeywordsCommand
 
 services:
 #    codebender_library.example:
@@ -40,6 +41,12 @@ services:
 
     codebender_api.invalidApi:
             class:  %codebender_api.invalidApi.class%
+            arguments:
+                entityManager: "@doctrine.orm.entity_manager"
+                containerInterface: "@service_container"
+
+    codebender_api.getKeywords:
+            class:  %codebender_api.getKeywords.class%
             arguments:
                 entityManager: "@doctrine.orm.entity_manager"
                 containerInterface: "@service_container"

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -25,6 +25,24 @@ class ApiControllerTest extends WebTestCase
     }
 
     /**
+     * This method test the getKeywords API.
+     */
+    public function testGetKeywords()
+    {
+        $client = static::createClient();
+
+        $authorizationKey = $client->getContainer()->getParameter('authorizationKey');
+
+        $client = $this->postApiRequest($client, $authorizationKey, '{"type":"getKeywords", "library":"EEPROM"}');
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(true, $response['success']);
+        $this->assertArrayHasKey('keywords', $response);
+        $this->assertArrayHasKey('KEYWORD1', $response['keywords']);
+        $this->assertEquals('EEPROM', $response['keywords']['KEYWORD1'][0]);
+    }
+
+    /**
      * Use this method for library manager API requests with POST data
      *
      * @param Client $client


### PR DESCRIPTION
This PR builds upon PR #39 (API base).

This API is used to list all the keywords of a given library (header) read from they `keywords.txt` file found in the library version's directory.

## Usage
POST `{"type":"getKeywords","library":"<header_name>",”version”:”<version_number>”}` to the API dispatcher

## Example
POST `{"type":"getKeywords","library":"EEPROM"}` returns `{"success": true, "keywords": {"KEYWORD1": ["EEPROM"]}}`
Note that the version of EEPROM is omitted here since EEPROM is a built-in library.