### PR TITLE
Check header file name collision when adding new library

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Controller/ApiViewsController.php
+++ b/Symfony/src/Codebender/LibraryBundle/Controller/ApiViewsController.php
@@ -161,6 +161,29 @@ class ApiViewsController extends Controller
         return new JsonResponse(['success' => true]);
     }
 
+    /**
+     * Try get the library meta from the system
+     *
+     * @param $library
+     * @return JsonResponse
+     */
+    public function getLibraryMetaAction($library) {
+        if ($this->getRequest()->getMethod() != 'POST') {
+            return new JsonResponse(['success' => false, 'message' => 'POST method required']);
+        }
+
+        $apiHandler = $this->get('codebender_library.apiHandler');
+        $exists = $apiHandler->isExternalLibrary($library, true);
+
+        if (!$exists) {
+            return new JsonResponse(['success' => false, 'message' => 'Library not found.']);
+        }
+
+        $lib = $apiHandler->getLibraryFromDefaultHeader($library);
+
+        return new JsonResponse(['success' => true, 'meta' => $lib->getLibraryMeta()]);
+    }
+
     public function getLibraryGitInfoAction()
     {
         if ($this->getRequest()->getMethod() != 'POST') {

--- a/Symfony/src/Codebender/LibraryBundle/Resources/config/routing.yml
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/config/routing.yml
@@ -42,6 +42,11 @@ codebender_library_get_repo_tree_meta_v2:
     defaults: {_controller:CodebenderLibraryBundle:ApiViews:getRepoGitTreeAndMeta}
     methods:  [POST]
 
+codebender_library_get_library_meta:
+    pattern: /{authorizationKey}/v2/getLibMeta/{library}
+    defaults: {_controller:CodebenderLibraryBundle:ApiViews:getLibraryMeta}
+    methods:  [POST]
+
 codebender_library_view_library:
     pattern:  /{authorizationKey}/view
     defaults: { _controller: CodebenderLibraryBundle:Views:viewLibrary }

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/newLibForm.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/newLibForm.html.twig
@@ -113,7 +113,7 @@
                     <h4 class="modal-title">Header file name already exists</h4>
                 </div>
                 <div class="modal-body">
-                    <p>The header file name of the library already exists in our system.</p>
+                    <p id="modalMessage"></p>
                     <p>Do you wish to continue as adding a new version to the library?</p>
                 </div>
                 <div class="modal-footer">

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/newLibForm.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/newLibForm.html.twig
@@ -105,6 +105,24 @@
             </div>
         </div>
     </div>
+    <!-- A modal used when header name collision happen -->
+    <div id="myModal" class="modal fade" tabindex="-1" role="dialog">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Header file name already exists</h4>
+                </div>
+                <div class="modal-body">
+                    <p>The header file name of the library already exists in our system.</p>
+                    <p>Are you wish to continue and add as a new version for the existing library?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" id="modal-cancel">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="modal-button-ok">Add as new version</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
 
 </body>
 

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/newLibForm.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/newLibForm.html.twig
@@ -114,7 +114,7 @@
                 </div>
                 <div class="modal-body">
                     <p>The header file name of the library already exists in our system.</p>
-                    <p>Are you wish to continue and add as a new version for the existing library?</p>
+                    <p>Do you wish to continue as adding a new version to the library?</p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" id="modal-cancel">Cancel</button>

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
@@ -44,6 +44,46 @@
         $('#jstreeDiv').jstree(true).refresh(false, true);
     }
 
+    function updateLibraryMeta(name)
+    {
+        var route = "{{ path('codebender_library_get_library_meta', {'authorizationKey': authorizationKey, 'library': "LIBRARYNAME"}) }}";
+        $.post( route.replace("LIBRARYNAME", name) )
+            .done(function(data) {
+                if (data.success) {
+                    populateLibraryMeta(data.meta);
+                    $("#newLibMessage").html('<span><i class="fa fa-exclamation-triangle"></i></span> Default header found in system: add as new version');
+                } else {
+                    enableLibraryMetaInput();
+                    $("#newLibMessage").html('<span><i class="fa fa-exclamation-triangle"></i></span> Add new library');
+                }
+            });
+    }
+
+    function enableLibraryMetaInput() {
+        $("#newLibrary_Name").removeAttr("disabled");
+        $("#newLibrary_Description").removeAttr("disabled");
+        $("#newLibrary_Notes").removeAttr("disabled");
+        $("#newLibrary_Url").removeAttr("disabled");
+
+        $("#newLibrary_Name").val('');
+        $("#newLibrary_Description").val('');
+        $("#newLibrary_Notes").val('');
+        $("#newLibrary_Url").val('');
+    }
+
+    function populateLibraryMeta(meta) {
+        // disabled fields
+        $("#newLibrary_Name").attr("disabled", "disabled");
+        $("#newLibrary_Description").attr("disabled", "disabled");
+        $("#newLibrary_Notes").attr("disabled", "disabled");
+        $("#newLibrary_Url").attr("disabled", "disabled");
+        // populate fields
+        $("#newLibrary_Name").val(meta.name);
+        $("#newLibrary_Description").val(meta.description);
+        $("#newLibrary_Notes").val(meta.libraryNotes);
+        $("#newLibrary_Url").val(meta.url);
+    }
+
     function get_github_info()
     {
         var $url = $("#githubUrl").val();
@@ -97,7 +137,10 @@
 
     function update_machineName()
     {
-        $("#newLibrary_DefaultHeader").val($("#machineNames").val());
+        var machineName = $("#machineNames").val();
+        $("#newLibrary_DefaultHeader").val(machineName);
+        // check if the machine name exists in the databse
+        updateLibraryMeta(machineName);
     }
 
     function update_git(owner, repo, ref, description, isFromRelease)

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
@@ -34,7 +34,7 @@
                     $("#newLibMessage").html('<span><i class="fa fa-times-circle"></i></span> Failed to fetch the repository correctly. Please try again.');
                     return;
                 }
-                update_git(data.owner, data.repo, data.ref, data.description, isFromRelease)
+                update_git(data.owner, data.repo, data.ref, data.description, isFromRelease);
             });
     }
 
@@ -50,8 +50,17 @@
         $.post( route.replace("LIBRARYNAME", name) )
             .done(function(data) {
                 if (data.success) {
-                    populateLibraryMeta(data.meta);
-                    $("#newLibMessage").html('<span><i class="fa fa-exclamation-triangle"></i></span> Default header found in system: add as new version');
+                    // header file name collision
+                    // ask for user option
+                    $('#myModal').modal('show');
+                    $('#modal-button-ok').click(function() {
+                        $('#myModal').modal('hide');
+                        populateLibraryMeta(data.meta);
+                        $("#newLibMessage").html('<span><i class="fa fa-exclamation-triangle"></i></span> Default header found in system: add as new version');
+                    });
+                    $('#modal-cancel').click(function() {
+                        location.reload(); // reset the progress
+                    });
                 } else {
                     enableLibraryMetaInput();
                     $("#newLibMessage").html('<span><i class="fa fa-exclamation-triangle"></i></span> Add new library');
@@ -375,6 +384,13 @@
                 $('#orDiv').show();
                 $('#zipDiv').show();
             }
+        });
+
+        // set up modal
+        $('#myModal').modal({
+            keyboard: false,
+            show: false,
+            backdrop: 'static'
         });
 
         /*

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
@@ -6,8 +6,8 @@
         $("#newLibMessage").html('<span><i class="fa fa-cog fa-spin"></i></span> Fetching file tree..');
         var $url = $("#githubUrl").val();
         var $ref = isFromRelease ? $("#gitReleases").val() : $("#gitBranches").val();
-        $.post( "{{ path('codebender_library_get_repo_tree_meta_v2', {'authorizationKey' : authorizationKey}) }}", { githubUrl: $url, gitRef : $ref })
-            .done(function( data ) {
+        $.post("{{ path('codebender_library_get_repo_tree_meta_v2', {'authorizationKey' : authorizationKey}) }}", { githubUrl: $url, gitRef : $ref })
+            .done(function(data) {
                 if(!data.success) {
                     $("#newLibMessage").html('<span><i class="fa fa-times-circle"></i></span> There is no such library');
                     return;
@@ -47,7 +47,7 @@
     function updateLibraryMeta(name)
     {
         var route = "{{ path('codebender_library_get_library_meta', {'authorizationKey': authorizationKey, 'library': "LIBRARYNAME"}) }}";
-        $.post( route.replace("LIBRARYNAME", name) )
+        $.post(route.replace("LIBRARYNAME", name))
             .done(function(data) {
                 if (data.success) {
                     // header file name collision
@@ -103,8 +103,8 @@
         }
 
         $("#newLibMessage").html('<span><i class="fa fa-cog fa-spin"></i></span> Fetching data..');
-        $.post( "{{ path('codebender_library_get_library_git_info', {'authorizationKey' : authorizationKey}) }}", { githubUrl: $url })
-            .done(function( data ) {
+        $.post("{{ path('codebender_library_get_library_git_info', {'authorizationKey' : authorizationKey}) }}", { githubUrl: $url })
+            .done(function(data) {
                 if(data.success)
                 {
                     if (data.branches && data.releases) {

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Api/page-logic.html.twig
@@ -52,6 +52,7 @@
                 if (data.success) {
                     // header file name collision
                     // ask for user option
+                    $('#modalMessage').html('The header file name "<strong>' + name + '</strong>" of this library already exists in our system.');
                     $('#myModal').modal('show');
                     $('#modal-button-ok').click(function() {
                         $('#myModal').modal('hide');


### PR DESCRIPTION
Implement the front-end code to check default header file name when adding new library. Also add a new API to check for library meta using header file name.
If the header name already exists, now will populate the meta informations in the add new library form automatically and add it as a new version for the library.