### PR TITLE
Implement multiple partner authentication

### DIFF
--- a/Symfony/app/config/config.yml
+++ b/Symfony/app/config/config.yml
@@ -25,7 +25,7 @@ services:
         class: Codebender\LibraryBundle\EventListener\AuthenticationListener
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
-        arguments: [ %authorizationKey% ]
+        arguments: [ %authorizationKey%, @service_container ]
 
 # Twig Configuration
 twig:

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
@@ -4,6 +4,7 @@ namespace Codebender\LibraryBundle\Handler;
 
 use Codebender\LibraryBundle\Entity\Library;
 use Codebender\LibraryBundle\Entity\LibraryExample;
+use Codebender\LibraryBundle\Entity\Partner;
 use Codebender\LibraryBundle\Entity\Version;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
@@ -354,6 +355,15 @@ class ApiHandler
         $reponse = $this->curlGitRequest($url);
         $dateString = $reponse['committer']['date'];
         return strtotime($dateString);
+    }
+
+    public function isAuthenticatedPartner($auth_key)
+    {
+        /* @var Partner $partner */
+        $partner = $this->entityManager
+            ->getRepository('CodebenderLibraryBundle:Partner')
+            ->findOneBy(array('auth_key' => $auth_key));
+        return $partner !== null;
     }
 
     /**

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -468,6 +468,37 @@ class ApiControllerTest extends WebTestCase
     }
 
     /**
+     * This method tests the authentication mechanism of Eratosthenes
+     */
+    public function testApiAuthentication()
+    {
+        $client = static::createClient();
+        $invalidAuthorizationKey = 'thisIsAnInvalidAuthorizationKey';
+        $validV1AuthorizationKey = $client->getContainer()->getParameter('authorizationKey');
+        $validV2AuthorizationKey = $client->getContainer()->get('Doctrine')
+            ->getRepository('CodebenderLibraryBundle:Partner')
+            ->findOneBy(['name' => 'arduino.cc'])
+            ->getAuthKey();
+        $this->assertFailAuthorization($invalidAuthorizationKey);
+        $this->assertPassAuthorization($validV1AuthorizationKey);
+        $this->assertPassAuthorization($validV2AuthorizationKey);
+    }
+
+    private function assertFailAuthorization($authorizationKey) {
+        $client = static::createClient();
+        $client = $this->postApiRequest($client, $authorizationKey, '{"type":"status"}');
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(false, $response['success']);
+    }
+
+    private function assertPassAuthorization($authorizationKey) {
+        $client = static::createClient();
+        $client = $this->postApiRequest($client, $authorizationKey, '{"type":"status"}');
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(true, $response['success']);
+    }
+
+    /**
      * Use this method for library manager API requests with POST data
      *
      * @param Client $client


### PR DESCRIPTION
This PR implements support for the authentication of multiple partners. Support for the older version of authentication is still maintained.

Tests have also been created to test the authentication mechanism against invalid keys, v1 key and v2 keys.

Closes #52.