### PR TITLE
Combine builtin libraries with external libraries

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadLibraryData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadLibraryData.php
@@ -142,6 +142,23 @@ class LoadLibraryData extends AbstractFixture implements OrderedFixtureInterface
         // Persist the new library
         $objectManager->persist($binaryLbrary);
 
+        // From here on add all the internal libraries
+        $builtInLibs = ["EEPROM", "Ethernet", "GSM", "Robot_Control", "SD", "SoftwareSerial", "Stepper", "WiFi",
+            "Esplora", "Firmata", "LiquidCrystal", "Robot_Motor", "Servo", "SPI", "TFT", "Wire"];
+        foreach ($builtInLibs as $name) {
+            $builtInLib = new Library();
+            $builtInLib->setName($name);
+            $builtInLib->setDefaultHeader($name);
+            $builtInLib->setActive(true);
+            $builtInLib->setVerified(true);
+            $builtInLib->setDescription("Built-in library " . $name);
+            $builtInLib->setFolderName($name);
+            $builtInLib->setIsBuiltIn(true);
+
+            $this->setReference($name . 'Library', $builtInLib);
+            $objectManager->persist($builtInLib);
+        }
+
         /*
          * After all fixture objects have been added to the ObjectManager (`persist` operation),
          * it's time to flush the contents of the ObjectManager

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadLibraryExampleData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadLibraryExampleData.php
@@ -236,6 +236,27 @@ class LoadLibraryExamplesData extends AbstractFixture implements OrderedFixtureI
          */
         $objectManager->persist($encodeLibraryExample);
 
+
+        // From here on add the internal library examples. Only few are added.
+        $builtInLibs = [
+            "EEPROM" => ["eeprom_clear", "eeprom_read", "eeprom_write"],
+            "Robot_Control" => ["explore", "learn"]
+        ];
+        $builtInDefaultVersion = 'default';
+        foreach ($builtInLibs as $name => $examples) {
+            $builtInLibVersion = $this->getReference($name . ucfirst($builtInDefaultVersion) . 'Version');
+
+            foreach ($examples as $example) {
+                $builtInLibExample = new LibraryExample();
+                $builtInLibExample->setName($example);
+                $builtInLibExample->setVersion($builtInLibVersion);
+                $builtInLibExample->setPath('examples/' . $example . '/' . $example . '.ino');
+                $builtInLibExample->setBoards(null);
+
+                $objectManager->persist($builtInLibExample);
+            }
+        }
+
         /*
          * After all fixture objects have been added to the ObjectManager (`persist` operation),
          * it's time to flush the contents of the ObjectManager

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadLibraryExampleData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadLibraryExampleData.php
@@ -240,7 +240,10 @@ class LoadLibraryExamplesData extends AbstractFixture implements OrderedFixtureI
         // From here on add the internal library examples. Only few are added.
         $builtInLibs = [
             "EEPROM" => ["eeprom_clear", "eeprom_read", "eeprom_write"],
-            "Robot_Control" => ["explore", "learn"]
+            "Robot_Control" => ["explore", "learn"],
+            "WiFi" => ["ConnectNoEncryption", "ScanNetworks", "WiFiPachubeClient", "WiFiUdpNtpClient", "WiFiWebClientRepeating",
+                "ConnectWithWEP", "SimpleWebServerWiFi", "WiFiPachubeClientString", "WiFiUdpSendReceiveString", "WiFiWebServer",
+                "ConnectWithWPA", "WiFiChatServer", "WiFiTwitterClient", "WiFiWebClient"]
         ];
         $builtInDefaultVersion = 'default';
         foreach ($builtInLibs as $name => $examples) {

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadVersionData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadVersionData.php
@@ -159,6 +159,22 @@ class LoadVersionData extends AbstractFixture implements OrderedFixtureInterface
         $this->setReference('EncodeLibraryVersion1', $encodeLibraryVersion1);
         $objectManager->persist($encodeLibraryVersion1);
 
+        // From here on add all the internal libraries
+        $builtInLibs = ["EEPROM", "Ethernet", "GSM", "Robot_Control", "SD", "SoftwareSerial", "Stepper", "WiFi",
+            "Esplora", "Firmata", "LiquidCrystal", "Robot_Motor", "Servo", "SPI", "TFT", "Wire"];
+        $builtInDefaultVersion = 'default';
+        foreach ($builtInLibs as $name) {
+            $lib = $this->getReference($name . 'Library');
+
+            $builtInLib = new Version();
+            $builtInLib->setVersion($builtInDefaultVersion);
+            $builtInLib->setLibrary($lib);
+            $builtInLib->setDescription("Built-in library " . $name . " default version.");
+            $builtInLib->setFolderName($builtInDefaultVersion);
+
+            $objectManager->persist($builtInLib);
+        }
+
         /*
          * After all fixture objects have been added to the ObjectManager (`persist` operation),
          * it's time to flush the contents of the ObjectManager

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadVersionData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadVersionData.php
@@ -159,7 +159,7 @@ class LoadVersionData extends AbstractFixture implements OrderedFixtureInterface
         $this->setReference('EncodeLibraryVersion1', $encodeLibraryVersion1);
         $objectManager->persist($encodeLibraryVersion1);
 
-        // From here on add all the internal libraries
+        // From here on add all the internal library versions
         $builtInLibs = ["EEPROM", "Ethernet", "GSM", "Robot_Control", "SD", "SoftwareSerial", "Stepper", "WiFi",
             "Esplora", "Firmata", "LiquidCrystal", "Robot_Motor", "Servo", "SPI", "TFT", "Wire"];
         $builtInDefaultVersion = 'default';
@@ -172,6 +172,7 @@ class LoadVersionData extends AbstractFixture implements OrderedFixtureInterface
             $builtInLib->setDescription("Built-in library " . $name . " default version.");
             $builtInLib->setFolderName($builtInDefaultVersion);
 
+            $this->setReference($name . ucfirst($builtInDefaultVersion) . 'Version', $builtInLib);
             $objectManager->persist($builtInLib);
         }
 

--- a/Symfony/src/Codebender/LibraryBundle/Entity/Library.php
+++ b/Symfony/src/Codebender/LibraryBundle/Entity/Library.php
@@ -122,6 +122,11 @@ class Library
     private $versions;
 
     /**
+     * @ORM\Column(name="is_built_in", type="boolean")
+     */
+    private $is_built_in = false;
+
+    /**
      * Get id
      *
      * @return integer
@@ -468,6 +473,28 @@ class Library
     public function getVersions()
     {
         return $this->versions;
+    }
+
+    /**
+     * Check whether it is built in
+     *
+     * @return boolean
+     */
+    public function isBuiltIn()
+    {
+        return $this->is_built_in;
+    }
+
+    /**
+     * Set whether it is built in
+     *
+     * @return Library
+     */
+    public function setIsBuiltIn($is_built_in)
+    {
+        $this->is_built_in = $is_built_in;
+
+        return $this;
     }
 
     /**

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/FetchApiCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/FetchApiCommand.php
@@ -19,100 +19,89 @@ class FetchApiCommand extends AbstractApiCommand
 
         $apiHandler = $this->container->get('codebender_library.apiHandler');
 
-        $builtinLibrariesPath = $this->container->getParameter('builtin_libraries');
         $externalLibrariesPath = $this->container->getParameter('external_libraries_new');
 
         $finder = new Finder();
         $exampleFinder = new Finder();
 
         //TODO handle the case of different .h filenames and folder names
-        $reservedNames = ["ArduinoRobot" => "Robot_Control", "ArduinoRobotMotorBoard" => "Robot_Motor",
+        $RESERVED_NAMES = ["ArduinoRobot" => "Robot_Control", "ArduinoRobotMotorBoard" => "Robot_Motor",
             "BlynkSimpleSerial" => "BlynkSimpleEthernet", "BlynkSimpleCC3000" => "BlynkSimpleEthernet"];
-        if (array_key_exists($filename, $reservedNames)) {
-            $filename = $reservedNames[$filename];
+        if (array_key_exists($filename, $RESERVED_NAMES)) {
+            $filename = $RESERVED_NAMES[$filename];
         }
 
-        if ($apiHandler->isBuiltInLibrary($filename)) {
-            $response = $apiHandler->fetchLibraryFiles($finder, $builtinLibrariesPath . "/libraries/" . $filename);
+        if (!$apiHandler->isExternalLibrary($filename, $content['disabled'])) {
+            return ["success" => false, "message" => "No Library named " . $filename . " found."];
+        }
+
+        // check if requested (if any) version is valid
+        if ($content['version'] !== null && !$apiHandler->libraryVersionExists($filename, $content['version'])) {
+            return [
+                'success' => false,
+                'message' => 'No files for Library named `' . $filename . '` with version `' . $content['version'] . '` found.'
+            ];
+        }
+
+        $versionObjects = $apiHandler->getAllVersionsFromDefaultHeader($filename);
+
+        // use the requested version (if any) for fetching data
+        // else fetch data for all versions
+        $versions = $versionObjects->toArray();
+        if ($content['version'] !== null) {
+            $versionsCollection = $versionObjects->filter(function ($version) use ($content) {
+                return $version->getVersion() === $content['version'];
+            });
+            $versions = $versionsCollection->toArray();
+        }
+
+        // fetch library files for each version
+        $response = [];
+        $examples = [];
+        foreach ($versions as $version) {
+            /* @var Version $version */
+            $libraryPath = $externalLibrariesPath . "/" . $filename . "/" . $version->getFolderName();
+
+            // fetch library files for this version
+            $fetchResponse = $apiHandler->fetchLibraryFiles($finder->create(), $libraryPath);
+            if (!empty($fetchResponse)) {
+                $response[$version->getVersion()] = $fetchResponse;
+            }
 
             if ($content['renderView']) {
-                $examples = $apiHandler->fetchLibraryExamples($exampleFinder, $builtinLibrariesPath . "/libraries/" . $filename);
-                $meta = [];
-                $versions = [];
+                // fetch example files for this version if it's rendering view
+                $exampleResponse = $apiHandler->fetchLibraryExamples($exampleFinder->create(), $libraryPath);
+                if (!empty($exampleResponse)) {
+                    $examples[$version->getVersion()] = $exampleResponse;
+                }
             }
+        }
+
+        if ($content['renderView']) {
+            $externalLibrary = $this->entityManager->getRepository('CodebenderLibraryBundle:Library')
+                ->findOneBy(array('default_header' => $filename));
+            $filename = $externalLibrary->getDefaultHeader();
+            $meta = $externalLibrary->getLibraryMeta();
+            $versions = array_map(
+                function ($version) {
+                    return $version->getVersion();
+                },
+                $versions
+            );
+
+            $result = [
+                'success' => true,
+                'library' => $filename,
+                'versions' => $versions,
+                'files' => $response,
+                'examples' => $examples,
+                'meta' => $meta
+            ];
         } else {
-            if (!$apiHandler->isExternalLibrary($filename, $content['disabled'])) {
-                return ["success" => false, "message" => "No Library named " . $filename . " found."];
-            }
-
-            // check if requested (if any) version is valid
-            if ($content['version'] !== null && !$apiHandler->libraryVersionExists($filename, $content['version'])) {
-                return [
-                    'success' => false,
-                    'message' => 'No files for Library named `' . $filename . '` with version `' . $content['version'] . '` found.'
-                ];
-            }
-
-            $versionObjects = $apiHandler->getAllVersionsFromDefaultHeader($filename);
-
-            // use the requested version (if any) for fetching data
-            // else fetch data for all versions
-            $versions = $versionObjects->toArray();
-            if ($content['version'] !== null) {
-                $versionsCollection = $versionObjects->filter(function ($version) use ($content) {
-                    return $version->getVersion() === $content['version'];
-                });
-                $versions = $versionsCollection->toArray();
-            }
-
-            // fetch library files for each version
-            $response = [];
-            $examples = [];
-            foreach ($versions as $version) {
-                /* @var Version $version */
-                $libraryPath = $externalLibrariesPath . "/" . $filename . "/" . $version->getFolderName();
-
-                // fetch library files for this version
-                $fetchResponse = $apiHandler->fetchLibraryFiles($finder->create(), $libraryPath);
-                if (!empty($fetchResponse)) {
-                    $response[$version->getVersion()] = $fetchResponse;
-                }
-
-                if ($content['renderView']) {
-                    // fetch example files for this version if it's rendering view
-                    $exampleResponse = $apiHandler->fetchLibraryExamples($exampleFinder->create(), $libraryPath);
-                    if (!empty($exampleResponse)) {
-                        $examples[$version->getVersion()] = $exampleResponse;
-                    }
-                }
-            }
-
-            if ($content['renderView']) {
-                $externalLibrary = $this->entityManager->getRepository('CodebenderLibraryBundle:Library')
-                    ->findOneBy(array('default_header' => $filename));
-                $filename = $externalLibrary->getDefaultHeader();
-                $meta = $externalLibrary->getLibraryMeta();
-                $versions = array_map(
-                    function ($version) {
-                        return $version->getVersion();
-                    },
-                    $versions
-                );
-            }
+            $result = ['success' => true, 'message' => 'Library found', 'files' => $response];
         }
 
-        if (!$content['renderView']) {
-            return ['success' => true, 'message' => 'Library found', 'files' => $response];
-        }
-
-        return [
-            'success' => true,
-            'library' => $filename,
-            'versions' => $versions,
-            'files' => $response,
-            'examples' => $examples,
-            'meta' => $meta
-        ];
+        return $result;
     }
 
     private function setDefault($content)

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/FetchApiCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/FetchApiCommand.php
@@ -31,7 +31,7 @@ class FetchApiCommand extends AbstractApiCommand
             $filename = $RESERVED_NAMES[$filename];
         }
 
-        if (!$apiHandler->isExternalLibrary($filename, $content['disabled'])) {
+        if (!$apiHandler->isLibrary($filename, $content['disabled'])) {
             return ["success" => false, "message" => "No Library named " . $filename . " found."];
         }
 

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetExampleCodeCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetExampleCodeCommand.php
@@ -33,8 +33,7 @@ class GetExampleCodeCommand extends AbstractApiCommand
 
         switch ($type) {
             case 'builtin':
-                $dir = $handler->getBuiltInLibraryPath($library);
-                $example = $this->getExampleCodeFromDir($dir, $example);
+                $example = $this->getExternalExampleCode($library, $version, $example);
                 break;
             case 'external':
                 $example = $this->getExternalExampleCode($library, $version, $example);
@@ -65,7 +64,6 @@ class GetExampleCodeCommand extends AbstractApiCommand
         if (count($exampleMeta) === 0) {
             $example = str_replace(":", "/", $example);
             $filename = pathinfo($example, PATHINFO_FILENAME);
-
             $exampleMeta = $handler->getExampleForExternalLibrary($library, $version, $filename);
 
             if (count($exampleMeta) > 1) {

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetExamplesCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetExamplesCommand.php
@@ -19,27 +19,21 @@ class GetExamplesCommand extends AbstractApiCommand
 
         /* @var ApiHandler $handler */
         $handler = $this->get('codebender_library.apiHandler');
-        $type = $handler->getLibraryType($library);
+        $libraryType = $handler->getLibraryType($library);
 
-        if ($type === 'unknown') {
+        if ($libraryType === 'unknown') {
             return ['success' => false, 'message' => 'Requested library named ' . $library . ' not found'];
         }
-
 
         if (!$handler->libraryVersionExists($library, $version)) {
             return ['success' => false, 'message' => 'Requested version for library ' . $library . ' not found'];
         }
 
-        $path = "";
-        /*
-         * Assume the requested library is an example
-         */
-        $path = $handler->getBuiltInLibraryExamplePath($library);
-        if ($type === 'external') {
+        $path = '';
+        if ($libraryType === 'external' || $libraryType === 'builtin') {
             $path = $handler->getExternalLibraryPath($library, $version);
-        }
-        if ($type === 'builtin') {
-            $path = $handler->getBuiltInLibraryPath($library);
+        } else if ($libraryType === 'example') {
+            $path = $handler->getBuiltInLibraryExamplePath($library);
         }
 
         $examples = $this->getExampleFilesFromPath($path);

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetKeywordsCommand.php
@@ -39,10 +39,8 @@ class GetKeywordsCommand extends AbstractApiCommand
         }
 
         $libraryType = $this->apiHandler->getLibraryType($defaultHeader);
-        if ($libraryType === 'external') {
+        if ($libraryType === 'external' || $libraryType === 'builtin') {
             $keywords = $this->getExternalLibraryKeywords($defaultHeader, $version);
-        } elseif ($libraryType === 'builtin') {
-            $keywords = $this->getBuiltInLibraryKeywords($defaultHeader);
         } else {
             return ['success' => false];
         }
@@ -84,20 +82,6 @@ class GetKeywordsCommand extends AbstractApiCommand
     private function getExternalLibraryKeywords($defaultHeader, $version)
     {
         $path = $this->apiHandler->getExternalLibraryPath($defaultHeader, $version);
-        $keywords = $this->getKeywordsFromFile($path);
-        return $keywords;
-    }
-
-    /**
-     * This method returns an array of keywords from a given built-in library
-     * specified by its $defaultHeader.
-     *
-     * @param $defaultHeader
-     * @return array
-     */
-    private function getBuiltInLibraryKeywords($defaultHeader)
-    {
-        $path = $this->apiHandler->getBuiltInLibraryPath($defaultHeader);
         $keywords = $this->getKeywordsFromFile($path);
         return $keywords;
     }

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/ListApiCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/ListApiCommand.php
@@ -8,53 +8,23 @@ class ListApiCommand extends AbstractApiCommand
 {
     public function execute($content)
     {
-        $arduinoLibraryFiles = $this->container->getParameter('builtin_libraries') . "/";
-
-        $builtinExamples = $this->getLibariesListFromDir($arduinoLibraryFiles . "examples");
-        $includedLibraries = $this->getLibariesListFromDir($arduinoLibraryFiles . "libraries");
         /*
          * External libraries list is fetched from the database, because we need to list
          * active libraries only
          */
         $externalLibraries = $this->getLibraryList();
 
-        ksort($builtinExamples);
-        ksort($includedLibraries);
-        ksort($externalLibraries);
+        ksort($externalLibraries['Builtin Libraries']);
+        ksort($externalLibraries['External Libraries']);
 
         return [
             'success' => true,
             'text' => 'Successful Request!',
             'categories' => [
-                'Examples' => $builtinExamples,
-                'Builtin Libraries' => $includedLibraries,
-                'External Libraries' => $externalLibraries
+                'Builtin Libraries' => $externalLibraries['Builtin Libraries'],
+                'External Libraries' => $externalLibraries['External Libraries']
             ]
         ];
-    }
-
-    private function getLibariesListFromDir($path)
-    {
-
-        $finder = new Finder();
-        $finder->files()->name('*.ino')->name('*.pde');
-        $finder->in($path);
-
-        $libraries = array();
-
-        foreach ($finder as $file) {
-            $names = $this
-                ->getExampleAndLibNameFromRelativePath(
-                    $file->getRelativePath(),
-                    $file->getBasename("." . $file->getExtension())
-                );
-
-            if (!isset($libraries[$names['library_name']])) {
-                $libraries[$names['library_name']] = array("description" => "", "examples" => array());
-            }
-            $libraries[$names['library_name']]['examples'][] = array('name' => $names['example_name']);
-        }
-        return $libraries;
     }
 
     private function getLibraryList()
@@ -64,15 +34,21 @@ class ListApiCommand extends AbstractApiCommand
             ->getRepository('CodebenderLibraryBundle:Library')
             ->findBy(array('active' => true));
 
-        $libraries = array();
+        $libraries = ['Builtin Libraries' => [], 'External Libraries' => []];
         foreach ($externalMeta as $library) {
+            if ($library->isBuiltIn()) {
+                $category = 'Builtin Libraries';
+            } else {
+                $category = 'External Libraries';
+            }
+
             $defaultHeader = $library->getDefaultHeader();
 
-            $libraries[$defaultHeader] = array();
+            $libraries[$category][$defaultHeader] = array();
 
             $versions = $library->getVersions();
             foreach ($versions as $version) {
-                $libraries[$defaultHeader][$version->getVersion()] = array(
+                $libraries[$category][$defaultHeader][$version->getVersion()] = array(
                     "description" => $library->getDescription(),
                     "name" => $library->getName(),
                     "url" => "http://github.com/" . $library->getOwner() . "/" . $library->getRepo(),
@@ -90,7 +66,7 @@ class ListApiCommand extends AbstractApiCommand
                             $example->getName()
                         );
 
-                    $libraries[$defaultHeader][$version->getVersion()]['examples'][] = $names['example_name'];
+                    $libraries[$category][$defaultHeader][$version->getVersion()]['examples'][] = $names['example_name'];
                 }
             }
         }

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
@@ -111,11 +111,9 @@ class ApiHandler
      */
     public function isBuiltInLibrary($defaultHeader)
     {
-        if (!is_dir($this->getBuiltInLibraryPath($defaultHeader))) {
-            return false;
-        }
+        $lib = $this->getLibraryFromDefaultHeader($defaultHeader);
 
-        return true;
+        return $lib->isBuiltIn();
     }
 
     /**

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
@@ -67,6 +67,7 @@ class ApiHandler
         return $path;
     }
 
+    // TODO: this function is obsolete
     public function getBuiltInLibraryPath($defaultHeader)
     {
         $builtInLibraryRoot = $this->container->getParameter('builtin_libraries');
@@ -74,6 +75,7 @@ class ApiHandler
         return $path;
     }
 
+    // TODO: this function is obsolete
     public function getBuiltInLibraryExamplePath($exmapleName)
     {
         $builtInLibraryRoot = $this->container->getParameter('builtin_libraries');
@@ -111,9 +113,12 @@ class ApiHandler
      */
     public function isBuiltInLibrary($defaultHeader)
     {
-        $lib = $this->getLibraryFromDefaultHeader($defaultHeader);
+        $library = $this->getLibraryFromDefaultHeader($defaultHeader);
 
-        return $lib->isBuiltIn();
+        if ($library === null) {
+            return false;
+        }
+        return $library->isBuiltIn();
     }
 
     /**
@@ -143,7 +148,10 @@ class ApiHandler
     {
         $library = $this->getLibraryFromDefaultHeader($defaultHeader);
 
-        return $getDisabled ? $library !== null : $library !== null && $library->getActive();
+        if ($library === null || $library->isBuiltIn()) {
+            return false;
+        }
+        return $getDisabled ? true : $library->getActive();
     }
 
     /**

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
@@ -46,6 +46,7 @@ class ApiHandler
      * @param $defaultHeader
      * @param $version
      * @return string
+     * TODO: consider changing name into getLibraryPath
      */
     public function getExternalLibraryPath($defaultHeader, $version)
     {
@@ -68,6 +69,7 @@ class ApiHandler
     }
 
     // TODO: rearrange filesystem to completely remove builtin_libraries parameter
+    // TODO: consider changing name into getArduinoExamplePath
     public function getBuiltInLibraryExamplePath($exmapleName)
     {
         $builtInLibraryRoot = $this->container->getParameter('builtin_libraries');
@@ -125,6 +127,7 @@ class ApiHandler
      *
      * @param $defaultHeader
      * @return bool
+     * TODO: consider changing name into isArduinoExample
      */
     public function isBuiltInLibraryExample($defaultHeader)
     {
@@ -209,6 +212,7 @@ class ApiHandler
      * @param $version
      * @param $example
      * @return array
+     * TODO: consider changing name into getExampleForLibrary
      */
     public function getExampleForExternalLibrary($library, $version, $example)
     {

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
@@ -67,15 +67,7 @@ class ApiHandler
         return $path;
     }
 
-    // TODO: this function is obsolete
-    public function getBuiltInLibraryPath($defaultHeader)
-    {
-        $builtInLibraryRoot = $this->container->getParameter('builtin_libraries');
-        $path = $builtInLibraryRoot . '/libraries/' . $defaultHeader;
-        return $path;
-    }
-
-    // TODO: this function is obsolete
+    // TODO: rearrange filesystem to completely remove builtin_libraries parameter
     public function getBuiltInLibraryExamplePath($exmapleName)
     {
         $builtInLibraryRoot = $this->container->getParameter('builtin_libraries');
@@ -93,9 +85,7 @@ class ApiHandler
      */
     public function libraryVersionExists($defaultHeader, $version, $checkDisabled = false)
     {
-        if ($this->isValidExternalLibraryVersion($defaultHeader, $version, $checkDisabled)) {
-            return true;
-        } elseif ($this->isBuiltInLibrary($defaultHeader)) {
+        if ($this->isValidLibraryVersion($defaultHeader, $version, $checkDisabled)) {
             return true;
         } elseif ($this->isBuiltInLibraryExample($defaultHeader)) {
             return true;
@@ -103,6 +93,14 @@ class ApiHandler
 
         return false;
     }
+
+    public function isLibrary($defaultHeader, $getDisabled = false)
+    {
+        $library = $this->getLibraryFromDefaultHeader($defaultHeader);
+
+        return $getDisabled ? $library !== null : $library !== null && $library->getActive();
+    }
+
 
     /**
      * This method checks if the given built-in library exists (specified by
@@ -389,9 +387,9 @@ class ApiHandler
      * @param bool $checkDisabled
      * @return bool
      */
-    private function isValidExternalLibraryVersion($defaultHeader, $version, $checkDisabled = false)
+    private function isValidLibraryVersion($defaultHeader, $version, $checkDisabled = false)
     {
-        if (!$this->isExternalLibrary($defaultHeader, $checkDisabled)) {
+        if (!$this->isLibrary($defaultHeader, $checkDisabled)) {
             return false;
         }
 

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -47,32 +47,19 @@ class ApiControllerTest extends WebTestCase
         $this->assertArrayHasKey('categories', $response);
         $categories = $response['categories'];
 
-        $this->assertArrayHasKey('Examples', $categories);
-        $this->assertNotEmpty($categories['Examples']);
-
         $this->assertArrayHasKey('Builtin Libraries', $categories);
         $this->assertNotEmpty($categories['Builtin Libraries']);
 
-        $basicExamples = $categories['Examples']['01.Basics']['examples'];
-
-        // Check for a specific, known example
-        $foundExample = array_filter($basicExamples, function($element) {
-            if ($element['name'] == 'AnalogReadSerial') {
-                return true;
-            }
-        });
-
-        $foundExample = array_values($foundExample);
-
-        // Make sure the example was found
-        $this->assertEquals('AnalogReadSerial', $foundExample[0]['name']);
+        $this->assertArrayHasKey('EEPROM', $categories['Builtin Libraries']);
+        $this->assertArrayHasKey('default', $categories['Builtin Libraries']['EEPROM']);
+        $this->assertTrue(in_array('eeprom_clear', $categories['Builtin Libraries']['EEPROM']['default']['examples']));
 
         $this->assertArrayHasKey('External Libraries', $categories);
         $this->assertNotEmpty($categories['External Libraries']);
 
+        $this->assertArrayHasKey('MultiIno', $categories['External Libraries']);
         $this->assertArrayHasKey('1.0.0', $categories['External Libraries']['MultiIno']);
         $this->assertArrayHasKey('2.0.0', $categories['External Libraries']['MultiIno']);
-
         $this->assertTrue(in_array('multi_ino_example', $categories['External Libraries']['MultiIno']['1.0.0']['examples']));
     }
 

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -107,7 +107,7 @@ class ApiControllerTest extends WebTestCase
 
         $authorizationKey = $client->getContainer()->getParameter('authorizationKey');
 
-        $client = $this->postApiRequest($client, $authorizationKey, '{"type":"getKeywords", "library":"EEPROM"}');
+        $client = $this->postApiRequest($client, $authorizationKey, '{"type":"getKeywords", "library":"EEPROM", "version":"default"}');
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(true, $response['success']);
         $this->assertArrayHasKey('keywords', $response);
@@ -192,7 +192,7 @@ class ApiControllerTest extends WebTestCase
         $client = $this->postApiRequest(
             $client,
             $authorizationKey,
-            '{"type":"getExamples", "library" : "EEPROM"}'
+            '{"type":"getExamples", "library" : "EEPROM", "version":"default"}'
         );
         $response = json_decode($client->getResponse()->getContent(), true);
 
@@ -304,7 +304,7 @@ class ApiControllerTest extends WebTestCase
         $client = $this->postApiRequest(
             $client,
             $authorizationKey,
-            '{"type":"getExampleCode", "library":"EEPROM", "example":"eeprom_read"}'
+            '{"type":"getExampleCode", "library":"EEPROM", "version":"default", "example":"eeprom_read"}'
         );
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertTrue($response['success']);
@@ -314,7 +314,7 @@ class ApiControllerTest extends WebTestCase
         $client = $this->postApiRequest(
             $client,
             $authorizationKey,
-            '{"type":"getExampleCode", "library":"WiFi", "example":"WiFiWebClient"}'
+            '{"type":"getExampleCode", "library":"WiFi", "version":"default", "example":"WiFiWebClient"}'
         );
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertTrue($response['success']);
@@ -438,6 +438,25 @@ class ApiControllerTest extends WebTestCase
         $this->assertContains('default.h', $filenames);
         $this->assertContains('inc_file.inc', $filenames);
         $this->assertContains('assembly_file.S', $filenames);
+    }
+
+    public function testFetchBuiltInApiCommand()
+    {
+        $client = static::createClient();
+        $authorizationKey = $client->getContainer()->getParameter('authorizationKey');
+        $client = $this->postApiRequest($client, $authorizationKey, '{ "type":"fetch", "library":"EEPROM", "version":"default" }');
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertTrue($response['success']);
+        $this->assertEquals('Library found', $response['message']);
+
+        $this->assertArrayHasKey('default', $response['files']);
+
+        $filenames = array_column($response['files']['default'], 'filename');
+        $this->assertContains('EEPROM.cpp', $filenames);
+        $this->assertContains('EEPROM.h', $filenames);
+        $this->assertContains('keywords.txt', $filenames);
     }
 
     /**

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiControllerTest.php
@@ -47,6 +47,24 @@ class ApiControllerTest extends WebTestCase
         $this->assertArrayHasKey('categories', $response);
         $categories = $response['categories'];
 
+        // Check Examples
+        $this->assertArrayHasKey('Examples', $categories);
+        $this->assertNotEmpty($categories['Examples']);
+
+        $basicExamples = $categories['Examples']['01.Basics']['examples'];
+        // Check for a specific, known example
+        $foundExample = array_filter($basicExamples, function($element) {
+            if ($element['name'] == 'AnalogReadSerial') {
+                return true;
+            }
+            return false;
+        });
+        $foundExample = array_values($foundExample);
+
+        // Make sure the example was found
+        $this->assertEquals('AnalogReadSerial', $foundExample[0]['name']);
+
+        // Check Builtin Libraries
         $this->assertArrayHasKey('Builtin Libraries', $categories);
         $this->assertNotEmpty($categories['Builtin Libraries']);
 
@@ -54,6 +72,7 @@ class ApiControllerTest extends WebTestCase
         $this->assertArrayHasKey('default', $categories['Builtin Libraries']['EEPROM']);
         $this->assertTrue(in_array('eeprom_clear', $categories['Builtin Libraries']['EEPROM']['default']['examples']));
 
+        // Check External Libraries
         $this->assertArrayHasKey('External Libraries', $categories);
         $this->assertNotEmpty($categories['External Libraries']);
 

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiViewsControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiViewsControllerTest.php
@@ -565,7 +565,7 @@ class ApiViewsControllerTest extends WebTestCase
         $this->assertEquals(
             1,
             $crawler->filter(
-                'a[href="/' . $authorizationKey . '/download/EEPROM"]:contains("Download from Eratosthenes")'
+                'a[href="/' . $authorizationKey . '/v2/download/EEPROM/default"]:contains("Version - default")'
             )->count());
 
         $this->assertEquals(1, $crawler->filter('a[class="collapsed"]:contains("EEPROM.h")')->count());


### PR DESCRIPTION
This PR will make builtin libraries to behave like external libraries.
Therefore, builtin libraries also requires version.
All the builtin libraries from the fixtures use `default` as their only version.
ex. `{ "type":"fetch", "library":"EEPROM", "version":"default" }`

As a consequence of combining those two library types, many files have changed.

The PR is divided and directed towards PR #57 so that Files Changed menu is not noised by simple copy and paste of files.