### PR TITLE
Fixed the way Github urls are returned when listing all libraries

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/LibraryBundle/Controller/DefaultController.php
@@ -412,25 +412,44 @@ class DefaultController extends Controller
     private function getExternalLibrariesList()
     {
         $entityManager = $this->getDoctrine()->getManager();
-        $externalMeta = $entityManager->getRepository('CodebenderLibraryBundle:ExternalLibrary')->findBy(array('active' => true));
+        $librariesEntities = $entityManager->getRepository('CodebenderLibraryBundle:ExternalLibrary')
+            ->findBy(['active' => true]);
 
-        $libraries = array();
-        foreach ($externalMeta as $library) {
+        $libraries = [];
+        foreach ($librariesEntities as $library) {
+            /* @var ExternalLibrary $library */
             $libraryMachineName = $library->getMachineName();
-            if (!isset($libraries[$libraryMachineName])) {
-                $libraries[$libraryMachineName] = array("description" => $library->getDescription(), "humanName" => $library->getHumanName(), "examples" => array());
-
-                if ($library->getOwner() !== null && $library->getRepo() !== null) {
-                    $libraries[$libraryMachineName] = array("description" => $library->getDescription(), "humanName" => $library->getHumanName(), "url" => "http://github.com/" . $library->getOwner() . "/" . $library->getRepo(), "examples" => array());
-                }
+            if (isset($libraries[$libraryMachineName])) {
+                continue;
             }
 
-            $examples = $entityManager->getRepository('CodebenderLibraryBundle:Example')->findBy(array('library' => $library));
+            $libraries[$libraryMachineName] = [
+                'description' => $library->getDescription(),
+                'humanName' => $library->getHumanName(),
+                'examples' => []
+            ];
+            $libraryUrl = $library->getUrl();
+            if ($libraryUrl != '') {
+                $libraries[$libraryMachineName]['url'] = $libraryUrl;
+            }
+
+            if ($library->getOwner() !== null && $library->getRepo() !== null) {
+                $libraries[$libraryMachineName] = [
+                    'url' => 'https://github.com/' . $library->getOwner() . '/' . $library->getRepo()
+                ];
+            }
+
+            $examples = $entityManager->getRepository('CodebenderLibraryBundle:Example')
+                ->findBy(['library' => $library]);
 
             foreach ($examples as $example) {
-                $names = $this->getExampleAndLibNameFromRelativePath(pathinfo($example->getPath(), PATHINFO_DIRNAME), $example->getName());
+                /* @var Example $example */
+                $names = $this->getExampleAndLibNameFromRelativePath(
+                    pathinfo($example->getPath(), PATHINFO_DIRNAME),
+                    $example->getName()
+                );
 
-                $libraries[$libraryMachineName]['examples'][] = array('name' => $names['example_name']);
+                $libraries[$libraryMachineName]['examples'][] = ['name' => $names['example_name']];
             }
 
 

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadExternalLibraryData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadExternalLibraryData.php
@@ -139,6 +139,26 @@ class LoadExternalLibraryData extends AbstractFixture implements OrderedFixtureI
         // Persist the new library
         $objectManager->persist($binaryLbrary);
 
+        $urlTestLibrary = new ExternalLibrary();
+        $urlTestLibrary->setHumanName('Url Tester');
+        $urlTestLibrary->setMachineName('UrlTester');
+        $urlTestLibrary->setActive(true);
+        $urlTestLibrary->setVerified(false);
+        $urlTestLibrary->setDescription('A library used for testing that git urls work fine.');
+        $urlTestLibrary->setOwner('owner');
+        $urlTestLibrary->setRepo('repository');
+
+        $objectManager->persist($urlTestLibrary);
+
+        $urlTestLibrary2 = new ExternalLibrary();
+        $urlTestLibrary2->setHumanName('No Url Library');
+        $urlTestLibrary2->setMachineName('NoUrl');
+        $urlTestLibrary2->setActive(true);
+        $urlTestLibrary2->setVerified(false);
+        $urlTestLibrary2->setDescription('Another library used for testing that git urls work fine.');
+
+        $objectManager->persist($urlTestLibrary2);
+
         /*
          * After all fixture objects have been added to the ObjectManager (`persist` operation),
          * it's time to flush the contents of the ObjectManager

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/DefaultControllerFunctionalTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/DefaultControllerFunctionalTest.php
@@ -76,6 +76,18 @@ class DefaultControllerFunctionalTest extends WebTestCase
 
         // Make sure the example was found
         $this->assertEquals('AnalogReadSerial', $foundExample[0]['name']);
+
+        $urlTesterLibrary = $categories['External Libraries']['UrlTester'];
+        $this->assertEquals('https://github.com/owner/repository', $urlTesterLibrary['url']);
+
+        // disable the library in order to avoid making the rest of the tests fail
+        $client->request('POST', '/' . $authorizationKey . '/toggleStatus/UrlTester');
+
+        $binaryLibrary = $categories['External Libraries']['Binary'];
+        $this->assertEquals('https://some/url.com', $binaryLibrary['url']);
+
+        $noUrlLibrary = $categories['External Libraries']['NoUrl'];
+        $this->assertArrayNotHasKey('url', $noUrlLibrary);
     }
 
 


### PR DESCRIPTION
### ChangeLog
- Updated the part of the getExternalLibrariesList method which returns
  the 'more info' url for each library. The url would only be returned
  if a Github repo and owner were stored in the database under this
  library.
- Added new fixture data for the tests of this bugfix.
- Added functional tests.

### Merge Process
Nothing special, just pull the code.

### Testing Steps
Head over to [codebender's libraries](https://codebender.cc/libraries) and look for `SparkFunBME280` library. No `More info` button should be available under the `/libraries` page or under the [library view page](https://codebender.cc/library/SparkFunBME280). On staging the `More info` button should show up in both places.

What's the deal: This library is stored as an external library on eratosthenes. When adding an external library to eratosthenes from Github, the respective `github-owner` and `github-repo` columns are filled in the database. Although the SparkFunBME280 library is a Github library, we had to make some changes to its file structure and upload it to eratosthenes using a zip file. We did however add a `more-info-url` which points to [the Github library](https://github.com/sparkfun/SparkFun_BME280_Arduino_Library). Due to the bug fixed in this PR, the Urls would never be returned, unless the `github-owner` and `github-repo` were filled in eratosthenes' database.
