### PR TITLE
Removed redundant JSON encoding/decoding

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Controller/ViewsController.php
+++ b/Symfony/src/Codebender/LibraryBundle/Controller/ViewsController.php
@@ -87,7 +87,7 @@ class ViewsController extends Controller
                 $lastCommit = $handler->getLastCommitFromGithub($data['GitOwner'], $data['GitRepo'], $data['GitBranch'], $path);
                 break;
             case 'zip':
-                $libraryStructure = json_decode($this->getLibFromZipFile($data["Zip"]), true);
+                $libraryStructure = $this->getLibFromZipFile($data["Zip"]);
                 break;
         }
 
@@ -454,23 +454,23 @@ class ViewsController extends Controller
             $handler = $this->get('codebender_library.handler');
             $zip->extractTo('/tmp/lib/');
             $zip->close();
-            $dir = json_decode($this->processZipDir('/tmp/lib'), true);
+            $dir = $this->processZipDir('/tmp/lib');
 
             if (!$dir['success']) {
                 return json_encode($dir);
             }
 
             $dir = $dir['directory'];
-            $baseDir = json_decode($handler->findBaseDir($dir), true);
+            $baseDir = $handler->findBaseDir($dir);
             if ($baseDir['success'] !== true) {
-                return json_encode($baseDir);
+                return $baseDir;
             }
 
             $baseDir = $baseDir['directory'];
 
-            return json_encode(['success' => true, 'library' => $baseDir]);
+            return ['success' => true, 'library' => $baseDir];
         } else {
-            return json_encode(['success' => false, 'message' => 'Could not unzip Archive. Code: ' . $opened]);
+            return ['success' => false, 'message' => 'Could not unzip Archive. Code: ' . $opened];
         }
     }
 
@@ -484,23 +484,21 @@ class ViewsController extends Controller
             }
 
             if (is_dir($path . '/' . $file)) {
-                $subdir = json_decode($this->processZipDir($path . '/' . $file), true);
+                $subdir = $this->processZipDir($path . '/' . $file);
                 if ($subdir['success'] !== true) {
-                    return json_encode($subdir);
+                    return $subdir;
                 }
                 array_push($files, $subdir['directory']);
             } else {
-                $file = json_decode($this->processZipFile($path . '/' . $file), true);
+                $file = $this->processZipFile($path . '/' . $file);
                 if ($file['success'] === true) {
                     array_push($files, $file['file']);
                 } else if ($file['message'] != "Bad Encoding") {
-                    return json_encode($file);
+                    return $file;
                 }
             }
         }
-        return json_encode(
-            ['success' => true, 'directory' => ['name' => substr($path, 9), 'type' => 'dir', 'contents' => $files]]
-        );
+        return ['success' => true, 'directory' => ['name' => substr($path, 9), 'type' => 'dir', 'contents' => $files]];
     }
 
     private function processZipFile($path)
@@ -508,10 +506,10 @@ class ViewsController extends Controller
         $contents = file_get_contents($path);
 
         if ($contents === null) {
-            return json_encode(['success' => false, 'message' => 'Could not read file ' . basename($path)]);
+            return ['success' => false, 'message' => 'Could not read file ' . basename($path)];
         }
 
-        return json_encode(['success' => true, 'file' => ['name' => basename($path), 'type' => 'file', 'contents' => $contents]]);
+        return ['success' => true, 'file' => ['name' => basename($path), 'type' => 'file', 'contents' => $contents]];
     }
 
     private function destroy_dir($dir)

--- a/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
@@ -386,7 +386,7 @@ class DefaultHandler
     {
         foreach ($dir['contents'] as $file) {
             if ($file['type'] == 'file' && strpos($file['name'], ".h") !== false)
-                return json_encode(array('success' => true, 'directory' => $dir));
+                return ['success' => true, 'directory' => $dir];
 
         }
 
@@ -395,7 +395,7 @@ class DefaultHandler
                 foreach ($file['contents'] as $f) {
                     if ($f['type'] == 'file' && strpos($f['name'], ".h") !== false) {
                         $file = $this->fixDirName($file);
-                        return json_encode(array('success' => true, 'directory' => $file));
+                        return ['success' => true, 'directory' => $file];
                     }
                 }
             }


### PR DESCRIPTION
### ChangeLog
Internal functions handling zip uploads used to comunicate with each
other using JSON encoded text. This would break any zip upload with
files containing multibyte sequenses. At the same time, eratosthenes'
responses can handle multibyte content.
All JSON encoding/decoding was removed.
No tests needed to be updated.

### Merge process
Nothing special

### Testing steps
- Try to upload [this library](https://github.com/adafruit/Adafruit_Sensor) to eratosthenes-dev using a zip file. This should fail.
- Update the branch on eratosthenes.
- Re-try. This time the zip upload should succeed.