### PR TITLE
Migrate v1 database and files to v2

### DIFF
--- a/Symfony/app/DoctrineMigrations/Version20160315081844.php
+++ b/Symfony/app/DoctrineMigrations/Version20160315081844.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Application\Migrations;
+
+use Codebender\LibraryBundle\Entity\Architecture;
+use Codebender\LibraryBundle\Entity\Example;
+use Codebender\LibraryBundle\Entity\ExternalLibrary;
+use Codebender\LibraryBundle\Entity\Library;
+use Codebender\LibraryBundle\Entity\LibraryExample;
+use Codebender\LibraryBundle\Entity\Partner;
+use Codebender\LibraryBundle\Entity\Preference;
+use Codebender\LibraryBundle\Entity\Version;
+use Codebender\LibraryBundle\Handler\DefaultHandler;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160315081844 extends AbstractMigration implements ContainerAwareInterface
+{
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Library ADD is_built_in TINYINT(1) NOT NULL');
+    }
+
+    public function postUp(Schema $schema)
+    {
+        /* @var EntityManager $entityManager */
+        $entityManager = $this->container->get('doctrine.orm.entity_manager');
+
+        /*
+         * 1. Create the AVR architecture that is supported by all existing libraries
+         */
+        $avrArchitecture = new Architecture();
+        $avrArchitecture->setName('AVR');
+        $entityManager->persist($avrArchitecture);
+        $entityManager->flush();
+
+        /*
+         * 2. Migrate existing external libraries and add AVR architecture to them
+         */
+        $externalLibraries = $entityManager->getRepository('CodebenderLibraryBundle:ExternalLibrary')
+            ->findAll();
+        /* @var ExternalLibrary $externalLibrary */
+        foreach ($externalLibraries as $externalLibrary) {
+            $defaultHeader = $externalLibrary->getMachineName();
+            print("Migrating external lib: $defaultHeader\n");
+
+            // Do not migrate the SD external library
+            if ($defaultHeader === 'SD') continue;
+
+            /*
+             * Migrate all the existing attributes
+             */
+            $library = new Library();
+            $library->setName($externalLibrary->getHumanName());
+            $library->setDefaultHeader($externalLibrary->getMachineName());
+            $library->setFolderName($externalLibrary->getMachineName());
+            $library->setDescription($externalLibrary->getDescription());
+            $library->setOwner($externalLibrary->getOwner());
+            $library->setRepo($externalLibrary->getRepo());
+            $library->setBranch($externalLibrary->getBranch());
+            $library->setInRepoPath($externalLibrary->getInRepoPath());
+            $library->setNotes($externalLibrary->getNotes());
+            $library->setVerified($externalLibrary->getVerified());
+            $library->setActive($externalLibrary->getActive());
+            $library->setLastCommit($externalLibrary->getLastCommit());
+            $library->setUrl($externalLibrary->getUrl());
+            $library->setIsBuiltIn(False);
+
+            $version = new Version();
+            $versionField = '1.0.0';
+            $version->setLibrary($library);
+            $version->setVersion($versionField);
+            $version->setDescription($externalLibrary->getDescription());
+            $version->setNotes($externalLibrary->getNotes());
+            $version->setSourceUrl($externalLibrary->getSourceUrl());
+            $version->setFolderName($versionField);
+            $version->addArchitecture($avrArchitecture);
+
+            $examples = $entityManager->getRepository('CodebenderLibraryBundle:Example')
+                ->findBy(['library' => $externalLibrary]);
+            /* @var Example $example */
+            foreach ($examples as $example) {
+                $position = strpos($example->getPath(), '/');
+                $newExamplePath = substr($example->getPath(), $position + 1);
+
+                $libraryExample = new LibraryExample();
+                $libraryExample->setName($example->getName());
+                $libraryExample->setVersion($version);
+                $libraryExample->setBoards($example->getBoards());
+                $libraryExample->setPath($newExamplePath);
+
+                $entityManager->persist($libraryExample);
+            }
+
+            $library->addVersion($version);
+            $library->setLatestVersion($version);
+
+            /*
+             * Persist and move library files
+             */
+            $entityManager->persist($library);
+            $entityManager->persist($version);
+            $this->moveExternalLibraryFiles($defaultHeader, $versionField);
+        }
+        $entityManager->flush();
+
+        /*
+         * 3. Migrate existing built-in libraries as external libraries and add AVR architecture to them
+         */
+        $builtInVersion = '1.0.5';
+        $builtInLibrariesPath = $this->container->getParameter('builtin_libraries') . '/libraries';
+        $finder = new Finder();
+        $finder->depth(0);
+        /* @var SplFileInfo $builtInLibrary */
+        foreach ($finder->in($builtInLibrariesPath) as $builtInLibrary) {
+            /*
+             * Migrate any existing attributes
+             */
+            $defaultHeader = $builtInLibrary->getFilename();
+            print("Migrating built-in lib: $defaultHeader\n");
+
+            $library = new Library();
+            $library->setName($defaultHeader);
+            $library->setDefaultHeader($defaultHeader);
+            $library->setFolderName($defaultHeader);
+            $library->setDescription($defaultHeader . ' v' . $builtInVersion);
+            $library->setVerified(True);
+            $library->setActive(True);
+            $library->setIsBuiltIn(True);
+
+            $version = new Version();
+            $version->setLibrary($library);
+            $version->setVersion($builtInVersion);
+            $version->setFolderName($builtInVersion);
+            $version->addArchitecture($avrArchitecture);
+
+            /* @var DefaultHandler $handler */
+            $handler = $this->container->get('codebender_library.handler');
+            $examples = $handler->fetchLibraryExamples(new Finder(), $builtInLibrary->getPathname());
+            foreach ($examples as $example) {
+                $libraryExample = new LibraryExample();
+                $libraryExample->setVersion($version);
+                $libraryExample->setName(pathinfo($example['filename'])['filename']);
+                $libraryExample->setPath($example['filename']);
+                $libraryExample->setBoards(null);
+
+                $entityManager->persist($libraryExample);
+            }
+
+            $library->addVersion($version);
+            $library->setLatestVersion($version);
+
+            /*
+             * Persist and move library files
+             */
+            $entityManager->persist($library);
+            $entityManager->persist($version);
+            $this->moveBuiltInLibraryFiles($builtInLibrary, $builtInVersion);
+        }
+        $entityManager->flush();
+
+        /*
+         * 4. Migrate existing authorization key
+         */
+        $authorizationKey = $this->container->getParameter('authorizationKey');
+        $codebender = new Partner();
+        $codebender->setName('Codebender');
+        $codebender->setAuthKey($authorizationKey);
+        $entityManager->persist($codebender);
+        $entityManager->flush();
+
+        /*
+         * 5. Set all existing versions as the preferred version for Codebender
+         */
+        $libraries = $entityManager->getRepository('CodebenderLibraryBundle:Library')->findAll();
+        /* @var Library $library */
+        foreach ($libraries as $library) {
+            $preference = new Preference();
+            $preference->setLibrary($library);
+            $preference->setVersion($library->getLatestVersion());
+            $codebender->addPreference($preference);
+
+            $entityManager->persist($preference);
+            $entityManager->persist($codebender);
+        }
+        $entityManager->flush();
+    }
+
+    /**
+     * This method moves an existing built-in library folder from the given sourceFolder to its
+     * new location. The old directory is removed after this operation.
+     *
+     * @param SplFileInfo $sourceFolder
+     * @param $version
+     */
+    private function moveBuiltInLibraryFiles(SplFileInfo $sourceFolder, $version)
+    {
+        $defaultHeader = $sourceFolder->getFilename();
+
+        /* @var Filesystem $filesystem */
+        $filesystem = new Filesystem();
+        $sourcePath = $sourceFolder->getPathname();
+        $destinationRootDirectory = $this->container->getParameter('external_libraries_new');
+        $destinationPath = $destinationRootDirectory . '/' . $defaultHeader . '/' . $version;
+        $filesystem->mirror($sourcePath, $destinationPath);
+        $filesystem->remove($sourcePath);
+    }
+
+    /**
+     * This method moves an existing external library folder from the existing location to its
+     * new location. The old directory is removed after this operation.
+     *
+     * @param $defaultHeader
+     * @param $version
+     */
+    private function moveExternalLibraryFiles($defaultHeader, $version)
+    {
+        /* @var Filesystem $filesystem */
+        $filesystem = new Filesystem();
+        $sourceRootDirectory = $this->container->getParameter('external_libraries');
+        $destinationRootDirectory = $this->container->getParameter('external_libraries_new');
+        $sourcePath = $sourceRootDirectory . '/' . $defaultHeader;
+        $destinationPath = $destinationRootDirectory . '/' . $defaultHeader . '/' . $version;
+        $filesystem->mirror($sourcePath, $destinationPath);
+        $filesystem->remove($sourcePath);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Library DROP is_built_in');
+    }
+}

--- a/Symfony/app/DoctrineMigrations/Version20160315081844.php
+++ b/Symfony/app/DoctrineMigrations/Version20160315081844.php
@@ -234,7 +234,7 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
         /* @var Filesystem $filesystem */
         $filesystem = new Filesystem();
         $sourcePath = $sourceFolder->getPathname();
-        $destinationRootDirectory = $this->container->getParameter('external_libraries_new');
+        $destinationRootDirectory = $this->container->getParameter('external_libraries_v2');
         $destinationPath = $destinationRootDirectory . '/' . $defaultHeader . '/' . $version;
         $filesystem->mirror($sourcePath, $destinationPath);
     }
@@ -251,7 +251,7 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
         /* @var Filesystem $filesystem */
         $filesystem = new Filesystem();
         $sourceRootDirectory = $this->container->getParameter('external_libraries');
-        $destinationRootDirectory = $this->container->getParameter('external_libraries_new');
+        $destinationRootDirectory = $this->container->getParameter('external_libraries_v2');
         $sourcePath = $sourceRootDirectory . '/' . $defaultHeader;
         $destinationPath = $destinationRootDirectory . '/' . $defaultHeader . '/' . $version;
         $filesystem->mirror($sourcePath, $destinationPath);

--- a/Symfony/app/DoctrineMigrations/Version20160315081844.php
+++ b/Symfony/app/DoctrineMigrations/Version20160315081844.php
@@ -48,11 +48,24 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
         $entityManager = $this->container->get('doctrine.orm.entity_manager');
 
         /*
-         * 1. Create the AVR architecture that is supported by all existing libraries
+         * 1. Create the various Arduino architectures
          */
         $avrArchitecture = new Architecture();
         $avrArchitecture->setName('AVR');
-        $entityManager->persist($avrArchitecture);
+
+        $esp8266Architecture = new Architecture();
+        $esp8266Architecture->setName('ESP8266');
+
+        $edisonArchitecture = new Architecture();
+        $edisonArchitecture->setName('Intel Edison');
+
+        $teensyArchitecture = new Architecture();
+        $teensyArchitecture->setName('Teensy');
+
+        $architectures = [$avrArchitecture, $esp8266Architecture, $edisonArchitecture, $teensyArchitecture];
+        foreach ($architectures as $architecture) {
+            $entityManager->persist($architecture);
+        }
         $entityManager->flush();
 
         /*

--- a/Symfony/app/DoctrineMigrations/Version20160315081844.php
+++ b/Symfony/app/DoctrineMigrations/Version20160315081844.php
@@ -224,7 +224,6 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
         $destinationRootDirectory = $this->container->getParameter('external_libraries_new');
         $destinationPath = $destinationRootDirectory . '/' . $defaultHeader . '/' . $version;
         $filesystem->mirror($sourcePath, $destinationPath);
-        $filesystem->remove($sourcePath);
     }
 
     /**
@@ -243,7 +242,6 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
         $sourcePath = $sourceRootDirectory . '/' . $defaultHeader;
         $destinationPath = $destinationRootDirectory . '/' . $defaultHeader . '/' . $version;
         $filesystem->mirror($sourcePath, $destinationPath);
-        $filesystem->remove($sourcePath);
     }
 
     /**

--- a/Symfony/app/DoctrineMigrations/Version20160315081844.php
+++ b/Symfony/app/DoctrineMigrations/Version20160315081844.php
@@ -60,6 +60,7 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
          */
         $externalLibraries = $entityManager->getRepository('CodebenderLibraryBundle:ExternalLibrary')
             ->findAll();
+        $externalLibraryVersion = 'CB-1';
         /* @var ExternalLibrary $externalLibrary */
         foreach ($externalLibraries as $externalLibrary) {
             $defaultHeader = $externalLibrary->getMachineName();
@@ -88,13 +89,12 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
             $library->setIsBuiltIn(False);
 
             $version = new Version();
-            $versionField = '1.0.0';
             $version->setLibrary($library);
-            $version->setVersion($versionField);
+            $version->setVersion($externalLibraryVersion);
             $version->setDescription($externalLibrary->getDescription());
             $version->setNotes($externalLibrary->getNotes());
             $version->setSourceUrl($externalLibrary->getSourceUrl());
-            $version->setFolderName($versionField);
+            $version->setFolderName($externalLibraryVersion);
             $version->addArchitecture($avrArchitecture);
 
             $examples = $entityManager->getRepository('CodebenderLibraryBundle:Example')
@@ -121,7 +121,7 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
              */
             $entityManager->persist($library);
             $entityManager->persist($version);
-            $this->moveExternalLibraryFiles($defaultHeader, $versionField);
+            $this->moveExternalLibraryFiles($defaultHeader, $externalLibraryVersion);
         }
         $entityManager->flush();
 

--- a/Symfony/app/DoctrineMigrations/Version20160315081844.php
+++ b/Symfony/app/DoctrineMigrations/Version20160315081844.php
@@ -10,7 +10,7 @@ use Codebender\LibraryBundle\Entity\LibraryExample;
 use Codebender\LibraryBundle\Entity\Partner;
 use Codebender\LibraryBundle\Entity\Preference;
 use Codebender\LibraryBundle\Entity\Version;
-use Codebender\LibraryBundle\Handler\DefaultHandler;
+use Codebender\LibraryBundle\Handler\ApiHandler;
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManager;
@@ -155,8 +155,8 @@ class Version20160315081844 extends AbstractMigration implements ContainerAwareI
             $version->setFolderName($builtInVersion);
             $version->addArchitecture($avrArchitecture);
 
-            /* @var DefaultHandler $handler */
-            $handler = $this->container->get('codebender_library.handler');
+            /* @var ApiHandler $handler */
+            $handler = $this->container->get('codebender_library.apiHandler');
             $examples = $handler->fetchLibraryExamples(new Finder(), $builtInLibrary->getPathname());
             foreach ($examples as $example) {
                 $libraryExample = new LibraryExample();

--- a/Symfony/app/config/parameters.yml.dist
+++ b/Symfony/app/config/parameters.yml.dist
@@ -13,7 +13,7 @@ parameters:
     # Paths to libraries.
     builtin_libraries: /opt/codebender/codebender-arduino-library-files
     external_libraries: /opt/codebender/codebender-external-library-files
-    external_libraries_new: /opt/codebender/codebender-external-library-files-new
+    external_libraries_v2: /opt/codebender/codebender-external-library-files-v2
 
     authorizationKey: "youMustChangeThis"
 

--- a/Symfony/src/Codebender/LibraryBundle/Command/LoadExternalLibraryFilesCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Command/LoadExternalLibraryFilesCommand.php
@@ -46,7 +46,7 @@ class LoadExternalLibraryFilesCommand extends ContainerAwareCommand
     {
         /* @var ContainerInterface $container */
         $container = $this->getContainer();
-        $path = 'external_libraries_new';
+        $path = 'external_libraries_v2';
         $source = 'library_files_new';
         $externalLibrariesPath = $container->getParameter($path);
         if ($externalLibrariesPath === null || $externalLibrariesPath === '') {

--- a/Symfony/src/Codebender/LibraryBundle/Entity/Library.php
+++ b/Symfony/src/Codebender/LibraryBundle/Entity/Library.php
@@ -130,7 +130,7 @@ class Library
      * @var integer
      *
      * @ORM\OneToOne(targetEntity="Version")
-     * @ORM\JoinColumn(name="latest_version", referencedColumnName="id", nullable = false)
+     * @ORM\JoinColumn(name="latest_version_id", referencedColumnName="id", nullable = false)
      */
     private $latest_version;
 

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/FetchApiCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/FetchApiCommand.php
@@ -23,7 +23,7 @@ class FetchApiCommand extends AbstractApiCommand
 
         $apiHandler = $this->container->get('codebender_library.apiHandler');
 
-        $externalLibrariesPath = $this->container->getParameter('external_libraries_new');
+        $externalLibrariesPath = $this->container->getParameter('external_libraries_v2');
 
         $finder = new Finder();
         $exampleFinder = new Finder();

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetExampleCodeCommand.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiCommand/GetExampleCodeCommand.php
@@ -183,7 +183,7 @@ class GetExampleCodeCommand extends AbstractApiCommand
      */
     private function getPathForExternalExample($example)
     {
-        $externalLibraryPath = $this->container->getParameter('external_libraries_new');
+        $externalLibraryPath = $this->container->getParameter('external_libraries_v2');
         $libraryFolder = $example->getVersion()->getLibrary()->getFolderName();
         $versionFolder = $example->getVersion()->getFolderName();
 

--- a/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/ApiHandler.php
@@ -52,7 +52,7 @@ class ApiHandler
      */
     public function getExternalLibraryPath($defaultHeader, $version)
     {
-        $externalLibraryRoot = $this->container->getParameter('external_libraries_new') . "/";
+        $externalLibraryRoot = $this->container->getParameter('external_libraries_v2') . "/";
 
         $library = $this->getLibraryFromDefaultHeader($defaultHeader);
         $libraryFolderName = $library->getFolderName();

--- a/Symfony/src/Codebender/LibraryBundle/Handler/NewLibraryHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/NewLibraryHandler.php
@@ -272,7 +272,7 @@ class NewLibraryHandler
     {
         $handler = $this->container->get('codebender_library.apiHandler');
 
-        $externalLibrariesPath = $this->container->getParameter('external_libraries_new');
+        $externalLibrariesPath = $this->container->getParameter('external_libraries_v2');
         $versionPath = $externalLibrariesPath . '/' . $lib->getFolderName() . '/' . $version->getFolderName();
         $examples = $handler->fetchLibraryExamples(new Finder(), $versionPath);
 
@@ -284,7 +284,7 @@ class NewLibraryHandler
 
     private function createLibraryDirectory($folderName, $libraryStructure)
     {
-        $path = $this->container->getParameter('external_libraries_new') . '/' . $folderName . '/';
+        $path = $this->container->getParameter('external_libraries_v2') . '/' . $folderName . '/';
         if (is_dir($path)) {
             return json_encode(array("success" => false, "message" => "Library directory already exists"));
         }
@@ -296,7 +296,7 @@ class NewLibraryHandler
 
     private function createVersionDirectory($libraryFolderName, $versionFolderName, $libraryStructure)
     {
-        $base = $path = $this->container->getParameter('external_libraries_new') . '/' . $libraryFolderName . '/' . $versionFolderName . '/';
+        $base = $path = $this->container->getParameter('external_libraries_v2') . '/' . $libraryFolderName . '/' . $versionFolderName . '/';
         return ($this->createVersionDirectoryRecur($base, $path, $libraryStructure['contents']));
     }
 

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiViewsControllerTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/ApiViewsControllerTest.php
@@ -171,7 +171,7 @@ class ApiViewsControllerTest extends WebTestCase
          * Check the files of the library have been stored on the filesystem.
          * TODO: Add a test for the validity of the files' contents.
          */
-        $externalLibrariesPath = $client->getContainer()->getParameter('external_libraries_new');
+        $externalLibrariesPath = $client->getContainer()->getParameter('external_libraries_v2');
         $libraryFolderName = $libraryEntity->getFolderName();
         $versionFolderName = $versionEntity->getFolderName();
         $versionPath = $externalLibrariesPath . '/' . $libraryFolderName . '/' . $versionFolderName . '/';
@@ -301,7 +301,7 @@ class ApiViewsControllerTest extends WebTestCase
          * Check the files of the library have been stored on the filesystem.
          * TODO: Add a test for the validity of the files' contents.
          */
-        $externalLibrariesPath = $client->getContainer()->getParameter('external_libraries_new');
+        $externalLibrariesPath = $client->getContainer()->getParameter('external_libraries_v2');
         $libraryFolderName = $libraryEntity->getFolderName();
         $versionFolderName = $versionEntity->getFolderName();
         $versionPath = $externalLibrariesPath . '/' . $libraryFolderName . '/' . $versionFolderName . '/';
@@ -469,7 +469,7 @@ class ApiViewsControllerTest extends WebTestCase
             'max_size.h'
         ];
 
-        $externalLibrariesPath = $client->getContainer()->getParameter('external_libraries_new');
+        $externalLibrariesPath = $client->getContainer()->getParameter('external_libraries_v2');
         $libraryFolderName = $libraryEntity->getFolderName();
         $versionFolderName = $versionEntity->getFolderName();
         $versionPath = $externalLibrariesPath . '/' . $libraryFolderName . '/' . $versionFolderName . '/';

--- a/Symfony/src/Codebender/LibraryBundle/Tests/Controller/DefaultControllerFunctionalTest.php
+++ b/Symfony/src/Codebender/LibraryBundle/Tests/Controller/DefaultControllerFunctionalTest.php
@@ -286,7 +286,7 @@ class DefaultControllerFunctionalTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $encodeLibraryPath = $client->getContainer()->getParameter('external_libraries_new') . '/Encode/1.0.0/';
+        $encodeLibraryPath = $client->getContainer()->getParameter('external_libraries_v2') . '/Encode/1.0.0/';
         $headerFile = file_get_contents($encodeLibraryPath . 'Encode.h');
         $exampleFile = file_get_contents($encodeLibraryPath . 'examples/encoded_example/encoded_example.ino');
         $malformedJson = json_encode(['header' => $headerFile, 'example' => $exampleFile]);

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -8,10 +8,10 @@ sudo cp -r arduino-library-files-master /opt/codebender/codebender-arduino-libra
 rm master.zip
 # Create the external libraries directory
 sudo mkdir /opt/codebender/codebender-external-library-files
-sudo mkdir /opt/codebender/codebender-external-library-files-new
+sudo mkdir /opt/codebender/codebender-external-library-files-v2
 
 # Give apache the correct permissions in order to write to the libraries directories
 sudo chown -R `whoami`:$HTTPDUSER /opt/codebender/codebender-arduino-library-files
 sudo chown -R `whoami`:$HTTPDUSER /opt/codebender/codebender-external-library-files
-sudo chown -R `whoami`:$HTTPDUSER /opt/codebender/codebender-external-library-files-new
+sudo chown -R `whoami`:$HTTPDUSER /opt/codebender/codebender-external-library-files-v2
 cd -


### PR DESCRIPTION
Supercedes PR #62.

## What this migration script does
1. Creates the AVR architecture
2. Migrate all existing external libraries (including examples) and add the AVR architecture to them
3. Migrate all existing built-in libraries as external libraries and also add the AVR architecture to them
4. Create Codebender as a new partner and migrate the existing authorization key as Codebender's authorization key in the new Partner table
5. Set all existing versions as the preferred version for Codebender

## 3 Outstanding To-dos:
- [x] Decide what version to set for existing external libraries
- [x] Decide if the older SD version needs to be migrated
- [x] Decide which SD version Codebender prefers

## How to use
1. Update code to v2 and make sure config files are correct
2. `cd` to the Symfony directory
3. Execute `php app/console doctrine:migrations:migrate`

## Screenshots
![image](https://cloud.githubusercontent.com/assets/10496851/13780824/fc077608-eafb-11e5-96ea-d56fde045045.png)
![image](https://cloud.githubusercontent.com/assets/10496851/13780871/1c0c61ac-eafc-11e5-9aaa-f4a8fd671eff.png)
