### PR TITLE
Determine files' mime type with mime_content_type

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
@@ -223,12 +223,10 @@ class DefaultHandler
         // $finder->name('*.cpp')->name('*.h')->name('*.c')->name('*.S')->name('*.inc')->name('*.txt');
         $finder->name('*.*');
 
-        $finfo = finfo_open(FILEINFO_MIME_TYPE);
-
         $response = array();
         foreach ($finder as $file) {
             if ($getContent) {
-                $mimeType = finfo_file($finfo, $file);
+                $mimeType = mime_content_type($file->getRealpath());
                 if (strpos($mimeType, "text/") === false)
                     $content = "/*\n *\n * We detected that this is not a text file.\n * Such files are currently not supported by our editor.\n * We're sorry for the inconvenience.\n * \n */";
                 else


### PR DESCRIPTION
### ChangeLog
Used `mime_content_type` instead of `finfo_file` in order to determine the mime type of libraries' files.

### Merge Process
- [ ] Diff libraries' returned files (via *fetch* API call).
- [ ] If libraries with diffs exist, will need to test all codebender projects somehow before merging. This is gonna be fun!