### PR TITLE
Updated git repo description validation in frontend

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Default/page-logic.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Default/page-logic.html.twig
@@ -29,7 +29,7 @@
                 $('#step2').show();
                 $('#step3').show();
 
-                if (!data.owner || !data.repo || !data.branch || !data.description) {
+                if (!data.owner || !data.repo || !data.branch || !typeof data.description == 'string') {
                     $("#newLibMessage").html('<span><i class="fa fa-times-circle"></i></span> Failed to fetch the repository correctly. Please try again.');
                     return;
                 }


### PR DESCRIPTION
### Changelog
Updated one of the frontend validation checks which did not allow the git properties (owner, repo, etc) to be populated if the repo description was an empty string. This would lead in an invalid form and make the library upload fail.

### Merge Process
Nothing special, just pull and clean cache.

### Testing Steps
Try uploading the https://github.com/RobolinkInc/CoDrone library using the git-upload feature in a staging version of eratosthenes. It should succeed, whereas the production version of eratosthenes failed as per kanbanize task #2704.