### PR TITLE
Hpp support

### DIFF
--- a/Symfony/src/Codebender/LibraryBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/LibraryBundle/Controller/DefaultController.php
@@ -313,7 +313,7 @@ class DefaultController extends Controller
 
             // TODO: Not only .h and .cpp files in Arduino examples
             $notInoFilesFinder = new Finder();
-            $notInoFilesFinder->files()->name('*.h')->name('*.cpp');
+            $notInoFilesFinder->files()->name('*.h')->name('*.cpp')->name('*.hpp');
             $notInoFilesFinder->in($path . "/" . $example->getRelativePath());
 
             foreach ($notInoFilesFinder as $nonInoFile) {
@@ -448,7 +448,7 @@ class DefaultController extends Controller
     {
         $filesFinder = new Finder();
         $filesFinder->in($dir);
-        $filesFinder->name('*.cpp')->name('*.h')->name('*.c')->name('*.S')->name('*.pde')->name('*.ino');
+        $filesFinder->name('*.hpp')->name('*.cpp')->name('*.h')->name('*.c')->name('*.S')->name('*.pde')->name('*.ino');
 
         $files = array();
         foreach ($filesFinder as $file) {

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadExternalLibraryData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadExternalLibraryData.php
@@ -24,6 +24,20 @@ class LoadExternalLibraryData extends AbstractFixture implements OrderedFixtureI
      */
     public function load(ObjectManager $objectManager)
     {
+        // A fake JSON library with hpp files in examples
+        $jsonlibr = new ExternalLibrary();
+        $jsonlibr->setHumanName('JSON Library');
+        $jsonlibr->setMachineName('jsonlib');
+        $jsonlibr->setActive(true);
+        $jsonlibr->setVerified(false);
+        $jsonlibr->setDescription('A library containing hpp files in examples which should be correctly fetched');
+        $jsonlibr->setSourceUrl('https://some/source/url.com');
+
+        // Reference to MultiIno library
+        $this->setReference('JsonLib', $jsonlibr);
+        $objectManager->persist($jsonlibr);
+
+
         // A fake version of the Adafruit GPS library
         $defaultLibrary = new ExternalLibrary();
         $defaultLibrary->setHumanName('Default Arduino Library');

--- a/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadExternalLibraryExamplesData.php
+++ b/Symfony/src/Codebender/LibraryBundle/DataFixtures/ORM/LoadExternalLibraryExamplesData.php
@@ -23,6 +23,29 @@ class LoadExternalLibraryExamplesData extends AbstractFixture implements Ordered
      */
     public function load(ObjectManager $objectManager)
     {
+        /* @var \Codebender\LibraryBundle\Entity\ExternalLibrary $jsonlibr */
+
+        $jsonlibr = $this->getReference('JsonLib');
+
+        $jsonexamplea = new Example();
+        $jsonexamplea->setName('JsonParserExample');
+        $jsonexamplea->setLibrary($jsonlibr);
+        $jsonexamplea->setPath('jsonlib/examples/JsonParserExample/JsonParserExample.ino');
+        $jsonexamplea->setBoards(null);
+
+        // Persist the new example
+        $objectManager->persist($jsonexamplea);
+
+        $jsonexampleb = new Example();
+        $jsonexampleb->setName('IndentedPrintExample');
+        $jsonexampleb->setLibrary($jsonlibr);
+        $jsonexampleb->setPath('jsonlib/examples/IndentedPrintExample/IndentedPrintExample.ino');
+        $jsonexampleb->setBoards(null);
+
+        // Persist the new example
+        $objectManager->persist($jsonexampleb);
+
+
         /* @var \Codebender\LibraryBundle\Entity\ExternalLibrary $defaultLibrary */
         $defaultLibrary = $this->getReference('defaultLibrary');
 

--- a/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
+++ b/Symfony/src/Codebender/LibraryBundle/Handler/DefaultHandler.php
@@ -618,7 +618,7 @@ class DefaultHandler
         $machineNames = array();
 
         foreach ($children as $child) {
-            if ($child['type'] == 'blob' && pathinfo($child['path'], PATHINFO_EXTENSION) == 'h') {
+            if ($child['type'] == 'blob' && (pathinfo($child['path'], PATHINFO_EXTENSION) == 'h' || pathinfo($child['path'], PATHINFO_EXTENSION) == 'hpp')) {
                 $machineNames[] = pathinfo($child['path'], PATHINFO_FILENAME);
             }
         }

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/JsonLibraryc.cpp
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/JsonLibraryc.cpp
@@ -1,0 +1,6 @@
+
+
+#ifdef ARDUINO
+
+
+#endif

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/JsonLibraryh.h
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/JsonLibraryh.h
@@ -1,0 +1,5 @@
+
+#ifdef ARDUINO
+
+
+#endif

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/JsonLibraryhp.hpp
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/JsonLibraryhp.hpp
@@ -1,0 +1,5 @@
+
+
+#ifdef ARDUINO
+
+#endif

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/IndentedPrintExample/IndentedPrintExample.ino
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/IndentedPrintExample/IndentedPrintExample.ino
@@ -1,0 +1,10 @@
+#include "PrintExamplehp.hpp"
+
+void setup() {
+int x= varde+5;
+  
+}
+
+void loop() {
+  // not used in this example
+}

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/IndentedPrintExample/PrintExamplehp.hpp
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/IndentedPrintExample/PrintExamplehp.hpp
@@ -1,0 +1,1 @@
+#define varde 2 ;

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/JsonParserExample/JsonLibrarycex.cpp
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/JsonParserExample/JsonLibrarycex.cpp
@@ -1,0 +1,3 @@
+#ifdef ARDUINO
+
+#endif

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/JsonParserExample/JsonParserExample.ino
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/JsonParserExample/JsonParserExample.ino
@@ -1,0 +1,9 @@
+#include "jsonlibex.h"
+
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  // not used in this example
+}

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/JsonParserExample/jsonlibex.h
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/examples/JsonParserExample/jsonlibex.h
@@ -1,0 +1,1 @@
+#include "JsonLibrarycex.cpp"

--- a/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/jsonlib.h
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/library_files/jsonlib/jsonlib.h
@@ -1,0 +1,5 @@
+
+#ifdef ARDUINO
+
+
+#endif

--- a/Symfony/src/Codebender/LibraryBundle/Resources/views/Default/page-logic.html.twig
+++ b/Symfony/src/Codebender/LibraryBundle/Resources/views/Default/page-logic.html.twig
@@ -138,8 +138,20 @@
                     $el.append($("<option></option>")
                         .attr("value", $name).text($name));
 
+                }else if(endsWith(entry.filename, ".hpp") && !startsWith(entry.filename, ".")  && !startsWith(entry.filename, "_") )
+                {
+                    var $lastSlash = entry.filename.lastIndexOf("/");
+                    var $header = entry.filename.substr($lastSlash+1);
+                    var $name = $header.substr(0,$header.length -4);
+                    $el.append($("<option></option>")
+                        .attr("value", $name).text($name));
+
                 }
-            });
+                
+            }
+                           
+                           
+                           );
             $el.prop("selected", false);
             update_machineName();
         });


### PR DESCRIPTION
What I fixed:
>Allow .hpp files as an option for "machine name"
>Enable controller to discover .hpp files inside examples
>Added dummy library "JSON Library" with examples  in order to test the .hpp files handling by eratosthenes and the compiler
 
After these changes all the tests through PhpUnit were completed successfully